### PR TITLE
Added example links, renamed Queued and Dequeued.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ __IMPORTANT NOTICE:__ The contents of this repository currectly reflect a __DRAF
    1. [The Links Object](./eiffel-syntax-and-usage/the-links-object.md)
    1. User Examples
 1. The Eiffel Vocabulary
-   1. [EiffelActivityQueuedEvent](./eiffel-vocabulary/EiffelActivityQueuedEvent.md)
-   1. [EiffelActivityDequeuedEvent](./eiffel-vocabulary/EiffelActivityDequeuedEvent.md)
+   1. [EiffelActivityTriggeredEvent](./eiffel-vocabulary/EiffelActivityTriggeredEvent.md)
+   1. [EiffelActivityCanceledEvent](./eiffel-vocabulary/EiffelActivityCancledEvent.md)
    1. [EiffelActivityStartedEvent](./eiffel-vocabulary/EiffelActivityStartedEvent.md)
    1. [EiffelActivityFinishedEvent](./eiffel-vocabulary/EiffelActivityFinishedEvent.md)
    1. [EiffelArtifactCreatedEvent](./eiffel-vocabulary/EiffelArtifactCreatedEvent.md)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ __IMPORTANT NOTICE:__ The contents of this repository currectly reflect a __DRAF
    1. User Examples
 1. The Eiffel Vocabulary
    1. [EiffelActivityTriggeredEvent](./eiffel-vocabulary/EiffelActivityTriggeredEvent.md)
-   1. [EiffelActivityCanceledEvent](./eiffel-vocabulary/EiffelActivityCancledEvent.md)
+   1. [EiffelActivityCanceledEvent](./eiffel-vocabulary/EiffelActivityCanceledEvent.md)
    1. [EiffelActivityStartedEvent](./eiffel-vocabulary/EiffelActivityStartedEvent.md)
    1. [EiffelActivityFinishedEvent](./eiffel-vocabulary/EiffelActivityFinishedEvent.md)
    1. [EiffelArtifactCreatedEvent](./eiffel-vocabulary/EiffelArtifactCreatedEvent.md)

--- a/eiffel-syntax-and-usage/the-links-object.md
+++ b/eiffel-syntax-and-usage/the-links-object.md
@@ -28,9 +28,9 @@ __Description:__ Identifies the flow context of the event: which is the continuo
 
 ### links.activityExecution
 __Type:__ String  
-__Required in:__ [EiffelActivityCanceledEvent](../eiffel-vocabulary/EiffelActivityCanceledEvent), 
-[EiffelActivityStartedEvent](../eiffel-vocabulary/EiffelActivityStartedEvent), 
-[EiffelActivityFinishedEvent](../eiffel-vocabulary/EiffelActivityFinishedEvent)  
+__Required in:__ [EiffelActivityCanceledEvent](../eiffel-vocabulary/EiffelActivityCanceledEvent.md), 
+[EiffelActivityStartedEvent](../eiffel-vocabulary/EiffelActivityStartedEvent.md), 
+[EiffelActivityFinishedEvent](../eiffel-vocabulary/EiffelActivityFinishedEvent.md)  
 __Optional in:__ None  
 __Legal targets:__ [EiffelActivityTriggeredEvent](../eiffel-vocabulary/EiffelActivityTriggeredEvent.md)  
 __Description:__ Declares the activity execution the event relates to. In other words, [EiffelActivityTriggeredEvent](../eiffel-vocabulary/EiffelActivityTriggeredEvent.md) acts as a handle for the activity execution. This differs from __links.context__. In __links.activityExecution__ the source carries information pertaining to the target (i.e. the activity started, finished or was canceled). In __links.context__, on the other hand, the source constitutes a subset of the target (e.g. this test case was executed as part of that activity or test suite).

--- a/eiffel-syntax-and-usage/the-links-object.md
+++ b/eiffel-syntax-and-usage/the-links-object.md
@@ -15,7 +15,7 @@ __Description:__ Identifies one or more causes of the event occurring. SHOULD no
 __Type:__ String  
 __Required in:__ None  
 __Optional in:__ Any  
-__Legal targets:__ [EiffelActivityQueuedEvent](../eiffel-vocabulary/EiffelActivityQueuedEvent.md), 
+__Legal targets:__ [EiffelActivityTriggeredEvent](../eiffel-vocabulary/EiffelActivityTriggeredEvent.md), 
 [EiffelTestSuiteStartedEvent](../eiffel-vocabulary/EiffelTestSuiteStartedEvent.md)  
 __Description:__ Identifies a the activity or test suite of which the event constitutes a part. SHOULD not be used in conjunction with __links.causes__, see above. Note that multiple layers may be modeled using __links.context__, e.g. an activity being part of another activity.
 
@@ -28,18 +28,18 @@ __Description:__ Identifies the flow context of the event: which is the continuo
 
 ### links.activityExecution
 __Type:__ String  
-__Required in:__ [EiffelActivityDequeuedEvent](../eiffel-vocabulary/EiffelActivityDequeuedEvent), 
+__Required in:__ [EiffelActivityCanceledEvent](../eiffel-vocabulary/EiffelActivityCanceledEvent), 
 [EiffelActivityStartedEvent](../eiffel-vocabulary/EiffelActivityStartedEvent), 
 [EiffelActivityFinishedEvent](../eiffel-vocabulary/EiffelActivityFinishedEvent)  
 __Optional in:__ None  
-__Legal targets:__ [EiffelActivityQueuedEvent](../eiffel-vocabulary/EiffelActivityQueuedEvent.md)  
-__Description:__ Declares the activity execution the event relates to. In other words, [EiffelActivityQueuedEvent](../eiffel-vocabulary/EiffelActivityQueuedEvent.md) acts as a handle for the activity execution. This differs from __links.context__. In __links.activityExecution__ the source carries information pertaining to the target (i.e. the activity started, finished or was dequeued). In __links.context__, on the other hand, the source constitutes a subset of the target (e.g. this test case was executed as part of that activity or test suite).
+__Legal targets:__ [EiffelActivityTriggeredEvent](../eiffel-vocabulary/EiffelActivityTriggeredEvent.md)  
+__Description:__ Declares the activity execution the event relates to. In other words, [EiffelActivityTriggeredEvent](../eiffel-vocabulary/EiffelActivityTriggeredEvent.md) acts as a handle for the activity execution. This differs from __links.context__. In __links.activityExecution__ the source carries information pertaining to the target (i.e. the activity started, finished or was canceled). In __links.context__, on the other hand, the source constitutes a subset of the target (e.g. this test case was executed as part of that activity or test suite).
 
 ### links.previousActivityExecution
 __Type:__ String  
 __Required in:__ None  
 __Optional in:__ [EiffelActivityStartedEvent](../eiffel-vocabulary/EiffelActivityStartedEvent.md)  
-__Legal targets:__ [EiffelActivityQueuedEvent](../eiffel-vocabulary/EiffelActivityQueuedEvent.md)  
+__Legal targets:__ [EiffelActivityTriggeredEvent](../eiffel-vocabulary/EiffelActivityTriggeredEvent.md)  
 __Description:__ Identifies the latest previous execution of the activity.
 
 ### links.previousVersions

--- a/eiffel-vocabulary/EiffelActivityCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelActivityCanceledEvent.md
@@ -1,0 +1,11 @@
+# EiffelActivityCanceledEvent
+The EiffelActivityCanceledEvent signals that a previously triggered activity execution has been canceled _before it has started_. This is typically used in queuing situations where a queued execution is dequeued. It is recommended that __links.causes__ be used to indicate the reason.
+
+## Data Members
+### data.reason
+__Type:__ String  
+__Required:__ No  
+__Description:__ Any human readable information as to the reason for dequeueing.
+
+## Examples
+* [Simple example](https://github.com/Ericsson/eiffel-examples/blob/master/events/EiffelActivityCanceledEvent/simple.json)

--- a/eiffel-vocabulary/EiffelActivityDequeuedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityDequeuedEvent.md
@@ -1,8 +1,0 @@
-# EiffelActivityDequeuedEvent
-The EiffelActivityDequeuedEvent signals that an activity previously queued for execution has been removed from the queue. It is recommended that __links.causes__ be used to indicate the reason.
-
-## Data Members
-### data.reason
-__Type:__ String  
-__Required:__ No  
-__Description:__ Any human readable information as to the reason for dequeueing.

--- a/eiffel-vocabulary/EiffelActivityFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityFinishedEvent.md
@@ -1,5 +1,5 @@
 # EiffelActivityFinishedEvent
-The EiffelActivityFinishedEvent declares that a previously started activity (declared by [EiffelActivityQueuedEvent](./EiffelActivityQueuedEvent.md) followed by [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md)) has finished.
+The EiffelActivityFinishedEvent declares that a previously started activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md) followed by [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md)) has finished.
 
 ## Data Members
 ### data.outcome
@@ -38,3 +38,6 @@ __Description:__ The name of the log file.
 __Type:__ String  
 __Required:__ Yes  
 __Description:__ The URI at which the log can be retrieved.
+
+## Examples
+* [Simple example](https://github.com/Ericsson/eiffel-examples/blob/master/events/EiffelActivityFinishedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelActivityStartedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityStartedEvent.md
@@ -1,5 +1,5 @@
 # EiffelActivityStartedEvent
-The EiffelActivityStartedEvent declares that a previously queued activity (declared by [EiffelActivityQueuedEvent](./EiffelActivityQueuedEvent.md)) has started.
+The EiffelActivityStartedEvent declares that a triggered queued activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md)) has started.
 
 ## Data Members
 ### data.executionUri
@@ -21,3 +21,6 @@ __Description:__ The name of the log file.
 __Type:__ String  
 __Required:__ Yes  
 __Description:__ The URI at which the log can be retrieved.
+
+## Examples
+* [Simple example](https://github.com/Ericsson/eiffel-examples/blob/master/events/EiffelActivityStartedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelActivityStartedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityStartedEvent.md
@@ -1,5 +1,5 @@
 # EiffelActivityStartedEvent
-The EiffelActivityStartedEvent declares that a triggered queued activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md)) has started.
+The EiffelActivityStartedEvent declares that a previously triggered activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md)) has started.
 
 ## Data Members
 ### data.executionUri

--- a/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
@@ -1,7 +1,7 @@
-# EiffelActivityQueuedEvent
-The EiffelActivityQueuedEvent declares that a certain activity - typically a build, test or analysis activity - has been queued for execution. This implies that it has been triggered by some factor, and the event serves the dual purpose of identifying this triggering factor.
+# EiffelActivityTriggeredEvent
+The EiffelActivityTriggeredEvent declares that a certain activity - typically a build, test or analysis activity - has been triggered by some factor. Note that this is crucially different from the activity execution having _started_ (as declared by [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md)).
 
-Many systems to not employ any queuing mechanism: an activity is simply started straight away when its triggering criteria are fulfilled. For coherence and consistency, the EiffelActivityQueuedEvent shall still be used: simply send the subsequent [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md) immediately after.
+In a situation where execution follows immediately upon triggering these two events should be sent together. Where that is not the case (e.g. due to queuing) the time delta between EiffelActivityTriggeredEvent and EiffelActivityStartedEvent constitutes the queue time.
 
 ## Data Members
 ### data.name
@@ -40,3 +40,6 @@ __Type:__ String
 __Required:__ No  
 __Legal values:__ MANUAL, SEMI_AUTOMATED, AUTOMATED, OTHER  
 __Description:__ The type of execution (often related to, but ultimately separate from, __data.trigger.type__).
+
+## Examples
+* [Simple example](https://github.com/Ericsson/eiffel-examples/blob/master/events/EiffelActivityTriggeredEvent/simple.json)

--- a/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
@@ -42,3 +42,5 @@ __Type:__ String
 __Required:__ No  
 __Description:__ The command used to build the artifact within the identified environment. Used for reproducability purposes.
 
+## Examples
+* [Simple example](https://github.com/Ericsson/eiffel-examples/blob/master/events/EiffelArtifactCreatedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
@@ -21,3 +21,6 @@ OTHER signifies other methods of retrieval. Note that using this type likely req
 __Type:__ String  
 __Required:__ Yes  
 __Description:__ The URI at which the artifact can be retrieved.
+
+## Examples
+* [Simple example](https://github.com/Ericsson/eiffel-examples/blob/master/events/EiffelArtifactPublishedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
+++ b/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
@@ -42,3 +42,6 @@ __Description:__ Any identity, alias or handle of the issuer, such as a corporat
 __Type:__ String  
 __Required:__ No  
 __Description:__ Any group, such as a development team, committee or test group, to which the issuer belongs.
+
+## Examples
+* [Simple example](https://github.com/Ericsson/eiffel-examples/blob/master/events/EiffelConfidenceLevelModifiedEvent/simple.json)


### PR DESCRIPTION
Each event has a link to a simple example in the eiffel-examples repo.

Renamed EiffelActivityQueuedEvent and EiffelActivityDequeuedEvent to
EiffelActivityTriggeredEvent and EiffelActivityCanceledEvent, respectively.