### PR TITLE
Move domainId from Meta to Meta.Source

### DIFF
--- a/eiffel-syntax-and-usage/the-meta-object.md
+++ b/eiffel-syntax-and-usage/the-meta-object.md
@@ -35,14 +35,14 @@ __Description:__ Any tags or keywords associated with the events, for searchabil
 ### meta.source
 __Type:__ Object  
 __Format:__  
-__Required:__ No  
+__Required:__ Yes
 __Description:__ A description of the event sender. Primarily for traceability purposes.
 
 #### meta.source.domainId
 __Type:__ String  
 __Format:__ Free text  
 __Required:__ Yes  
-__Description:__ Identifies the domain in which the event was produced. A domain is an infrastructure topological concept, which may or may not correspond to organization or product structures.
+__Description:__ Identifies the domain that produced an event. A domain is an infrastructure topological concept, which may or may not corresponds to an organization or product structures. A good example would be Java packages notation, ex. com.mycompany.product.component or mycompany.site.division. Also, keep in mind, that division names, as well as product/component names, tends to change. That is why it might be a good idea to pick coded names that do not directly reflect current naming in the organization. Think of flower names as names for sites or simply site1, site2, site3 instead of Sweden, Denmark, Norway.
 
 #### meta.source.host
 __Type:__ String  

--- a/eiffel-syntax-and-usage/the-meta-object.md
+++ b/eiffel-syntax-and-usage/the-meta-object.md
@@ -2,12 +2,6 @@
 The __meta__ object contains meta-information describing the event: when it was created, where it came from, its type et cetera. The __meta__ object contains the same members regardless of __meta.type__<sup>[1](#footnote1)</sup>, with the caveat that certain members are optional and the tendency to use them may vary with event type.
 
 ## Meta Members
-### meta.domainId
-__Type:__ String  
-__Format:__ Free text  
-__Required:__ Yes  
-__Description:__ Identifies the domain in which the event was produced. A domain is an infrastructure topological concept, which may or may not correspond to organization or product structures.
-
 ### meta.id
 __Type:__ String  
 __Format:__ [UUID](http://tools.ietf.org/html/rfc4122)  
@@ -43,6 +37,12 @@ __Type:__ Object
 __Format:__  
 __Required:__ No  
 __Description:__ A description of the event sender. Primarily for traceability purposes.
+
+#### meta.domainId
+__Type:__ String  
+__Format:__ Free text  
+__Required:__ Yes  
+__Description:__ Identifies the domain in which the event was produced. A domain is an infrastructure topological concept, which may or may not correspond to organization or product structures.
 
 #### meta.source.host
 __Type:__ String  

--- a/eiffel-syntax-and-usage/the-meta-object.md
+++ b/eiffel-syntax-and-usage/the-meta-object.md
@@ -38,7 +38,7 @@ __Format:__
 __Required:__ No  
 __Description:__ A description of the event sender. Primarily for traceability purposes.
 
-#### meta.domainId
+#### meta.source.domainId
 __Type:__ String  
 __Format:__ Free text  
 __Required:__ Yes  


### PR DESCRIPTION
DomainId seems to be belong to the source structure since it points out from which domain this message was sent to