### PR TITLE
Rewrote validation.py to perform schema validation

### DIFF
--- a/examples/validate.py
+++ b/examples/validate.py
@@ -11,12 +11,15 @@ def applySchema(schemaFileName):
   schemas +=1
   eventTypeName = schemaFileName[:-5]
   eventTypeDirName = "examples/events/" + eventTypeName
-  with open("schemas/" + schemaFileName, "r") as f:
-    schema = json.load(f)
-  
-  for root, dirnames, filenames in os.walk(eventTypeDirName):
-    for exampleFileName in fnmatch.filter(filenames, "*.json"):
-      validateExample(schema, os.path.join(root, exampleFileName))
+  try:
+    with open("schemas/" + schemaFileName, "r") as f:
+      schema = json.load(f)
+    
+    for root, dirnames, filenames in os.walk(eventTypeDirName):
+      for exampleFileName in fnmatch.filter(filenames, "*.json"):
+        validateExample(schema, os.path.join(root, exampleFileName))
+  except Exception as e:
+    reportFailure(e)
       
 def validateExample(schema, exampleFilePath):
   print("    ... ", exampleFilePath)
@@ -30,10 +33,13 @@ def validateExample(schema, exampleFilePath):
     validate(example, schema)
     print("         PASS")
   except Exception as e:
+    reportFailure(e)
+    
+def reportFailure(exception):
     global failures
     failures += 1
-    print("         FAIL:", type(e).__name__)
-    print("        ", e)
+    print("         FAIL:", type(exception).__name__)
+    print("        ", exception)
 
 failures = 0
 schemas = 0

--- a/examples/validate.py
+++ b/examples/validate.py
@@ -1,24 +1,49 @@
 #!/usr/bin/env python
-from __future__ import print_function
-import fnmatch
-import os
-import json
 import sys
+import json
+import os
+import fnmatch
+from jsonschema import validate
 
-print("Search for json files...")
-files = []
-for root, dirnames, filenames in os.walk('.'):
-    for filename in fnmatch.filter(filenames, '*.json'):
-        files.append(os.path.join(root, filename))
-
-for file in files:
-  print("Validating {}... ".format(file), end="")
-  with open(file, 'r') as myfile:
-    data=myfile.read()#.replace('\n', '')
+def applySchema(schemaFileName):
+  print("  - Applying", schemaFileName, "to ...")
+  global schemas
+  schemas +=1
+  eventTypeName = schemaFileName[:-5]
+  eventTypeDirName = "examples/events/" + eventTypeName
+  with open("schemas/" + schemaFileName, "r") as f:
+    schema = json.load(f)
+  
+  for root, dirnames, filenames in os.walk(eventTypeDirName):
+    for exampleFileName in fnmatch.filter(filenames, "*.json"):
+      validateExample(schema, os.path.join(root, exampleFileName))
+      
+def validateExample(schema, exampleFilePath):
+  print("    ... ", exampleFilePath)
+  global examples
+  examples +=1
+  exception = False
   try:
-    json.loads(data)
+    with open(exampleFilePath, "r") as f:
+      example = json.load(f)
+      
+    validate(example, schema)
+    print("         PASS")
   except Exception as e:
-    print("\n{}".format(data))
-    print(e)
-    sys.exit(1)
-  print("Ok")
+    global failures
+    failures += 1
+    print("         FAIL:", type(e).__name__)
+    print("        ", e)
+
+failures = 0
+schemas = 0
+examples = 0
+
+for root, dirNames, fileNames in os.walk("schemas"):
+    for schemaFileName in fnmatch.filter(fileNames, "*.json"):
+      applySchema(schemaFileName)
+
+print("Encountered", failures, "validation failures through application of", schemas, "schemas to", examples, "examples.")
+
+if failures > 0:
+  sys.exit("Validation failed.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema


### PR DESCRIPTION
Instead of simply verifying JSON syntax by attempting to load the example files, validate.py now searches for schemas and for each schema applies it to any examples of the corresponding type.

A minor drawback of this is that since currently the set of schemas is incomplete, not all examples will be thus verified. This is only temporary, however.

Once topic-drop3 is merged to master we'll add a Travis CI build status icon to README.