### PR TITLE
Introducing an explicit protocol versioning scheme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ __IMPORTANT NOTICE:__ The contents of this repository currectly reflect a __DRAF
    1. [Event Structure](./eiffel-syntax-and-usage/event-structure.md)
    1. [The Meta Object](./eiffel-syntax-and-usage/the-meta-object.md)
    1. [The Links Object](./eiffel-syntax-and-usage/the-links-object.md)
+   1. [Versioning](./eiffel-syntax-and-usage/versioning.md)
    1. [Compositions and Validity Checking](./eiffel-syntax-and-usage/compositions-and-validity-checking.md)
 1. The Eiffel Vocabulary
    1. [EiffelActivityTriggeredEvent](./eiffel-vocabulary/EiffelActivityTriggeredEvent.md)

--- a/eiffel-syntax-and-usage/the-meta-object.md
+++ b/eiffel-syntax-and-usage/the-meta-object.md
@@ -16,9 +16,9 @@ __Description:__ The type of event. This field is required by the recipient of t
 
 ### meta.version
 __Type:__ String  
-__Format:__ Semantic version excluding PATCH.  
+__Format:__ [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)  
 __Required:__ Yes  
-__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents.
+__Description:__ The version of the event type. This field is required by the recipient of the event to interpret the contents. Please see [Versioning](./versioning.md) for more information.
 
 ### meta.time
 __Type:__ Integer  

--- a/eiffel-syntax-and-usage/versioning.md
+++ b/eiffel-syntax-and-usage/versioning.md
@@ -1,0 +1,13 @@
+# Versioning
+In Eiffel, each individual event type is versioned independently. This version is declared by the __meta.version__ property (see [The Meta Object](./the-meta-object.md)) and follows the [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html) format. The documentation of each event type lists the complete version history of that type, including links to commits introducing older versions of the type.
+
+The independent versioning of event types, as opposed to a protocol-wide versioning scheme, was chosen for the greater flexibility and extensibility it affords. There are consequences, however, which are important to understand:
+* Consumers must always be ready to receive event types which they are unable to parse: the event producer may be ahead of the consumer on one event type, but not another. Similarly, new and/or custom event types must be expected and handled.
+* Backwards incompatible changes may not be introduced to the __meta.type__ and __meta.version__ properties, as these together form the key which allows the consumer to unlock the remainder of the event.
+
+That being said, to facilitate compatibility and consistency, the Eiffel protocol as described in this repository is released in named and internally coherent _editions_. Each of these editions is represented as a GitHub [release](https://github.com/Ericsson/eiffel/releases). A history of Eiffel editions is available below.
+
+| Edition   | Tag |
+| --------- | ------------------ |
+| Bordeaux  | _First edition. Not yet finished. Planned for end of [Drop 4](https://github.com/Ericsson/eiffel/milestone/4)._  |
+

--- a/eiffel-vocabulary/EiffelActivityCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelActivityCanceledEvent.md
@@ -7,5 +7,10 @@ __Type:__ String
 __Required:__ No  
 __Description:__ Any human readable information as to the reason for dequeueing.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelActivityCanceledEvent/simple.json)

--- a/eiffel-vocabulary/EiffelActivityFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityFinishedEvent.md
@@ -39,5 +39,10 @@ __Type:__ String
 __Required:__ Yes  
 __Description:__ The URI at which the log can be retrieved.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelActivityFinishedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelActivityStartedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityStartedEvent.md
@@ -22,5 +22,10 @@ __Type:__ String
 __Required:__ Yes  
 __Description:__ The URI at which the log can be retrieved.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelActivityStartedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
@@ -41,6 +41,11 @@ __Required:__ No
 __Legal values:__ MANUAL, SEMI_AUTOMATED, AUTOMATED, OTHER  
 __Description:__ The type of execution (often related to, but ultimately separate from, __data.trigger.type__).
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelActivityTriggeredEvent/simple.json)
 * [Example containing custom data](../examples/events/EiffelActivityTriggeredEvent/simple-customdata.json)

--- a/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
@@ -92,6 +92,11 @@ __Type:__ String
 __Required:__ Yes  
 __Description:__ The version of the dependency. Note that [version range notation](https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN402) is supported.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelArtifactCreatedEvent/simple.json)
 * [Interface example](../examples/events/EiffelArtifactCreatedEvent/interface.json)

--- a/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
@@ -22,5 +22,10 @@ __Type:__ String
 __Required:__ Yes  
 __Description:__ The URI at which the artifact can be retrieved.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelArtifactPublishedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
@@ -12,5 +12,10 @@ __Type:__ String
 __Required:__ No  
 __Description:__ The version of the composition, if any. This is in a sense redundant, as relationships between compositions can be tracked via the __PREVIOUS_VERSION__ link type, but can be used for improved clarity and semantics.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelCompositionDefinedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
+++ b/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
@@ -43,5 +43,10 @@ __Type:__ String
 __Required:__ No  
 __Description:__ Any group, such as a development team, committee or test group, to which the issuer belongs.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelConfidenceLevelModifiedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
@@ -39,6 +39,11 @@ __Type:__ String
 __Required:__ No  
 __Description:__ A URI identifying the environment description. This is the catch-all method of environment descriptions. Eiffel does not concern itself with the format or nature of the description, but merely points to its location.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [URI example](../examples/events/EiffelEnvironmentDefinedEvent/uri.json)
 * [Host example](../examples/events/EiffelEnvironmentDefinedEvent/host.json)

--- a/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
@@ -29,5 +29,10 @@ __Type:__ String
 __Required:__ No  
 __Description:__ A version context which other events can relate to. This member SHOULD be used in tandem with one of the other optional members - a version by itself is not very informative.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelFlowContextDefinedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
@@ -191,5 +191,11 @@ __Type:__ String
 __Required:__ Yes  
 __Description:__ The URI of the repo.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelSourceChangeCreatedEvent/simple.json)
+

--- a/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
@@ -126,5 +126,10 @@ __Type:__ String
 __Required:__ Yes  
 __Description:__ The URI of the repo.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelSourceChangeSubmittedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
@@ -51,5 +51,10 @@ __Type:__ String
 __Required:__ Yes  
 __Description:__ The URI at which the log can be retrieved.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelTestCaseFinishedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
@@ -63,5 +63,10 @@ __Type:__ String
 __Required:__ Yes  
 __Description:__ The URI at which the log can be retrieved.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelTestCaseStartedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
@@ -49,5 +49,10 @@ __Type:__ String
 __Required:__ Yes  
 __Description:__ The URI at which the log can be retrieved.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelTestSuiteFinishedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
@@ -35,5 +35,10 @@ __Type:__ String
 __Required:__ Yes  
 __Description:__ The URI at which the log can be retrieved.
 
+## Version History
+| Version   | Introducing Commit |
+| --------- | ------------------ |
+| 1.0.0     | _Current version_  |
+
 ## Examples
 * [Simple example](../examples/events/EiffelTestSuiteStartedEvent/simple.json)

--- a/examples/events/EiffelActivityCanceledEvent/simple.json
+++ b/examples/events/EiffelActivityCanceledEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelActivityCanceledEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelActivityFinishedEvent/simple.json
+++ b/examples/events/EiffelActivityFinishedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelActivityFinishedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelActivityStartedEvent/simple.json
+++ b/examples/events/EiffelActivityStartedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelActivityStartedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelActivityTriggeredEvent/simple-customdata.json
+++ b/examples/events/EiffelActivityTriggeredEvent/simple-customdata.json
@@ -2,7 +2,7 @@
   "meta": {
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "type": "EiffelActivityTriggeredEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "source": {
       "domainId": "test-domainId"

--- a/examples/events/EiffelActivityTriggeredEvent/simple.json
+++ b/examples/events/EiffelActivityTriggeredEvent/simple.json
@@ -2,7 +2,7 @@
   "meta": {
     "id": "e1e93f13-7c3c-4f17-9753-ebf0c86ff1c2",
     "type": "EiffelActivityTriggeredEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "source": {
       "domainId": "example.domain"

--- a/examples/events/EiffelArtifactCreatedEvent/backend.json
+++ b/examples/events/EiffelArtifactCreatedEvent/backend.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactCreatedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "source": {
       "domainId": "example.domain"

--- a/examples/events/EiffelArtifactCreatedEvent/dependent.json
+++ b/examples/events/EiffelArtifactCreatedEvent/dependent.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactCreatedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "source": {
       "domainId": "example.domain"

--- a/examples/events/EiffelArtifactCreatedEvent/interface.json
+++ b/examples/events/EiffelArtifactCreatedEvent/interface.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactCreatedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "source": {
       "domainId": "example.domain"

--- a/examples/events/EiffelArtifactCreatedEvent/simple.json
+++ b/examples/events/EiffelArtifactCreatedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactCreatedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelArtifactPublishedEvent/simple.json
+++ b/examples/events/EiffelArtifactPublishedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactPublishedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelCompositionDefinedEvent/simple.json
+++ b/examples/events/EiffelCompositionDefinedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelCompositionDefinedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "domainId": "example.domain",
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"

--- a/examples/events/EiffelConfidenceLevelModifiedEvent/simple.json
+++ b/examples/events/EiffelConfidenceLevelModifiedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelConfidenceLevelModifiedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelEnvironmentDefinedEvent/host.json
+++ b/examples/events/EiffelEnvironmentDefinedEvent/host.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelEnvironmentDefinedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelEnvironmentDefinedEvent/image.json
+++ b/examples/events/EiffelEnvironmentDefinedEvent/image.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelEnvironmentDefinedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelEnvironmentDefinedEvent/uri.json
+++ b/examples/events/EiffelEnvironmentDefinedEvent/uri.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelEnvironmentDefinedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelFlowContextDefinedEvent/simple.json
+++ b/examples/events/EiffelFlowContextDefinedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelFlowContextDefined",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "source": {
       "domainId": "example.domain"

--- a/examples/events/EiffelSourceChangeCreatedEvent/simple.json
+++ b/examples/events/EiffelSourceChangeCreatedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelSourceChangeCreatedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "domainId": "example.domain",
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"

--- a/examples/events/EiffelSourceChangeSubmittedEvent/simple.json
+++ b/examples/events/EiffelSourceChangeSubmittedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelSourceChangeSubmittedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "domainId": "example.domain",
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"

--- a/examples/events/EiffelTestCaseFinishedEvent/simple.json
+++ b/examples/events/EiffelTestCaseFinishedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelTestCaseFinishedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelTestCaseStartedEvent/simple.json
+++ b/examples/events/EiffelTestCaseStartedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelTestCaseStartedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelTestSuiteFinishedEvent/simple.json
+++ b/examples/events/EiffelTestSuiteFinishedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelTestSuiteFinishedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelTestSuiteStartedEvent/simple.json
+++ b/examples/events/EiffelTestSuiteStartedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelTestSuiteStartedEvent",
-    "version": "1.0",
+    "version": "1.0.0",
     "time": 1234567890,
     "source": {
       "domainId": "example.domain"

--- a/examples/flows/build-avoidance/events.json
+++ b/examples/flows/build-avoidance/events.json
@@ -2,7 +2,7 @@
   {
     "meta": {
       "type": "EiffelSourceChangeSubmittedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 1000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
       "source": {
@@ -18,7 +18,7 @@
   {
     "meta": {
       "type": "EiffelSourceChangeSubmittedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 101000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1",
       "source": {
@@ -38,7 +38,7 @@
   {
     "meta": {
       "type": "EiffelCompositionDefinedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 2000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2",
       "source": {
@@ -58,7 +58,7 @@
   {
     "meta": {
       "type": "EiffelCompositionDefinedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 102000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3",
       "source": {
@@ -82,7 +82,7 @@
   {
     "meta": {
       "type": "EiffelArtifactCreatedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 3000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4",
       "source": {
@@ -113,7 +113,7 @@
   {
     "meta": {
       "type": "EiffelArtifactCreatedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 4000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5",
       "source": {
@@ -144,7 +144,7 @@
   {
     "meta": {
       "type": "EiffelArtifactCreatedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 5000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee6",
       "source": {
@@ -175,7 +175,7 @@
   {
     "meta": {
       "type": "EiffelArtifactCreatedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 6000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee7",
       "source": {
@@ -206,7 +206,7 @@
   {
     "meta": {
       "type": "EiffelArtifactCreatedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 7000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee8",
       "source": {
@@ -237,7 +237,7 @@
   {
     "meta": {
       "type": "EiffelArtifactCreatedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 103000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee9",
       "source": {
@@ -272,7 +272,7 @@
   {
     "meta": {
       "type": "EiffelArtifactCreatedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 104000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee10",
       "source": {
@@ -307,7 +307,7 @@
   {
     "meta": {
       "type": "EiffelCompositionDefinedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 8000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee11",
       "source": {
@@ -343,7 +343,7 @@
   {
     "meta": {
       "type": "EiffelCompositionDefinedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 105000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee12",
       "source": {

--- a/examples/flows/confidence-level-joining/events.json
+++ b/examples/flows/confidence-level-joining/events.json
@@ -2,7 +2,7 @@
   {
     "meta": {
       "type": "EiffelEnvironmentDefinedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 1000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
       "source": {
@@ -18,7 +18,7 @@
   {
     "meta": {
       "type": "EiffelCompositionDefinedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 2000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1",
       "source": {
@@ -34,7 +34,7 @@
   {
     "meta": {
       "type": "EiffelArtifactCreatedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 3000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2",
       "source": {
@@ -73,7 +73,7 @@
   {
     "meta": {
       "type": "EiffelArtifactPublishedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 4000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3",
       "source": {
@@ -102,7 +102,7 @@
   {
     "meta": {
       "type": "EiffelActivityTriggeredEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 5000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4",
       "source": {
@@ -129,7 +129,7 @@
   {
     "meta": {
       "type": "EiffelActivityTriggeredEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 6000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5",
       "source": {
@@ -156,7 +156,7 @@
   {
     "meta": {
       "type": "EiffelActivityStartedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 7000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee6",
       "source": {
@@ -175,7 +175,7 @@
   {
     "meta": {
       "type": "EiffelActivityStartedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 8000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee7",
       "source": {
@@ -194,7 +194,7 @@
   {
     "meta": {
       "type": "EiffelTestCaseStartedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 9000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee8",
       "source": {
@@ -218,7 +218,7 @@
   {
     "meta": {
       "type": "EiffelTestCaseStartedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 9000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee9",
       "source": {
@@ -242,7 +242,7 @@
   {
     "meta": {
       "type": "EiffelTestCaseStartedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 9000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee10",
       "source": {
@@ -266,7 +266,7 @@
   {
     "meta": {
       "type": "EiffelTestCaseStartedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 9000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee11",
       "source": {
@@ -290,7 +290,7 @@
   {
     "meta": {
       "type": "EiffelTestCaseFinishedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 19000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee12",
       "source": {
@@ -310,7 +310,7 @@
   {
     "meta": {
       "type": "EiffelTestCaseFinishedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 14000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee13",
       "source": {
@@ -330,7 +330,7 @@
   {
     "meta": {
       "type": "EiffelTestCaseFinishedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 16000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee14",
       "source": {
@@ -350,7 +350,7 @@
   {
     "meta": {
       "type": "EiffelTestCaseFinishedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 15000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee15",
       "source": {
@@ -370,7 +370,7 @@
   {
     "meta": {
       "type": "EiffelActivityFinishedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 20000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee16",
       "source": {
@@ -392,7 +392,7 @@
   {
     "meta": {
       "type": "EiffelActivityFinishedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 20000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee17",
       "source": {
@@ -414,7 +414,7 @@
   {
     "meta": {
       "type": "EiffelConfidenceLevelModifiedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 21000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee18",
       "source": {

--- a/examples/flows/delivery-interface/events.json
+++ b/examples/flows/delivery-interface/events.json
@@ -2,7 +2,7 @@
   {
     "meta": {
       "type": "EiffelSourceChangeSubmittedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 1000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
       "source": {
@@ -18,7 +18,7 @@
   {
     "meta": {
       "type": "EiffelSourceChangeCreatedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 101000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1",
       "source": {
@@ -38,7 +38,7 @@
   {
     "meta": {
       "type": "EiffelSourceChangeCreatedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 102000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2",
       "source": {
@@ -62,7 +62,7 @@
   {
     "meta": {
       "type": "EiffelSourceChangeSubmittedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 103000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3",
       "source": {
@@ -86,7 +86,7 @@
   {
     "meta": {
       "type": "EiffelSourceChangeCreatedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 201000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4",
       "source": {
@@ -106,7 +106,7 @@
   {
     "meta": {    
       "type": "EiffelSourceChangeSubmittedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 202000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5",
       "source": {
@@ -130,7 +130,7 @@
   {
     "meta": {
       "type": "EiffelCompositionDefinedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 2000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee6",
       "source": {
@@ -150,7 +150,7 @@
   {
     "meta": {
       "type": "EiffelCompositionDefinedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 104000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee7",
       "source": {
@@ -174,7 +174,7 @@
   {
     "meta": {
       "type": "EiffelCompositionDefinedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 203000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee8",
       "source": {
@@ -198,7 +198,7 @@
   {
     "meta": {
       "type": "EiffelArtifactCreatedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 3000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee9",
       "source": {
@@ -229,7 +229,7 @@
   {
     "meta": {
       "type": "EiffelArtifactCreatedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 204000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee10",
       "source": {
@@ -260,7 +260,7 @@
   {
     "meta": {
       "type": "EiffelTestCaseStartedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 4000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee11",
       "source": {
@@ -280,7 +280,7 @@
   {
     "meta": {
       "type": "EiffelTestCaseStartedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 205000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee12",
       "source": {
@@ -300,7 +300,7 @@
   {
     "meta": {
       "type": "EiffelTestCaseFinishedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 5000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee13",
       "source": {
@@ -320,7 +320,7 @@
   {
     "meta": {
       "type": "EiffelTestCaseFinishedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 206000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee14",
       "source": {
@@ -340,7 +340,7 @@
   {
     "meta": {
       "type": "EiffelConfidenceLevelModifiedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 6000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee15",
       "source": {
@@ -361,7 +361,7 @@
   {
     "meta": {
       "type": "EiffelConfidenceLevelModifiedEvent",
-      "version": "1.0",
+      "version": "1.0.0",
       "time": 207000,
       "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee16",
       "source": {

--- a/schemas/EiffelActivityCanceledEvent.json
+++ b/schemas/EiffelActivityCanceledEvent.json
@@ -12,7 +12,8 @@
           "type": "string"
         },
         "version": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
         },
         "time": {
           "type": "integer"

--- a/schemas/EiffelActivityFinishedEvent.json
+++ b/schemas/EiffelActivityFinishedEvent.json
@@ -12,7 +12,8 @@
           "type": "string"
         },
         "version": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
         },
         "time": {
           "type": "integer"

--- a/schemas/EiffelActivityStartedEvent.json
+++ b/schemas/EiffelActivityStartedEvent.json
@@ -12,7 +12,8 @@
           "type": "string"
         },
         "version": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
         },
         "time": {
           "type": "integer"

--- a/schemas/EiffelActivityTriggeredEvent.json
+++ b/schemas/EiffelActivityTriggeredEvent.json
@@ -12,7 +12,8 @@
           "type": "string"
         },
         "version": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
         },
         "time": {
           "type": "integer"

--- a/schemas/EiffelArtifactCreatedEvent.json
+++ b/schemas/EiffelArtifactCreatedEvent.json
@@ -12,7 +12,8 @@
           "type": "string"
         },
         "version": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
         },
         "time": {
           "type": "integer"

--- a/schemas/EiffelArtifactPublishedEvent.json
+++ b/schemas/EiffelArtifactPublishedEvent.json
@@ -12,7 +12,8 @@
           "type": "string"
         },
         "version": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
         },
         "time": {
           "type": "integer"

--- a/schemas/EiffelConfidenceLevelModifiedEvent.json
+++ b/schemas/EiffelConfidenceLevelModifiedEvent.json
@@ -12,7 +12,8 @@
           "type": "string"
         },
         "version": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
         },
         "time": {
           "type": "integer"


### PR DESCRIPTION
Added documentation page for versioning.

Changed event type versioning from Semver excluding PATCH,
to Semver including PATCH. Updated all examples accordingly.

Added table of historical versions to each event type
documentation page.

Addresses issue #47.