### PR TITLE
Add meta.type validation

### DIFF
--- a/schemas/EiffelActivityCanceledEvent.json
+++ b/schemas/EiffelActivityCanceledEvent.json
@@ -9,7 +9,8 @@
           "type": "string"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "enum": ["EiffelActivityCanceledEventX"]
         },
         "version": {
           "type": "string",

--- a/schemas/EiffelActivityCanceledEvent.json
+++ b/schemas/EiffelActivityCanceledEvent.json
@@ -10,7 +10,7 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityCanceledEventX"]
+          "enum": ["EiffelActivityCanceledEvent"]
         },
         "version": {
           "type": "string",

--- a/schemas/EiffelActivityFinishedEvent.json
+++ b/schemas/EiffelActivityFinishedEvent.json
@@ -9,7 +9,8 @@
           "type": "string"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "enum": ["EiffelActivityFinishedEvent"]
         },
         "version": {
           "type": "string",
@@ -84,11 +85,11 @@
             "conclusion": {
               "type": "string",
               "enum": [
-                "SUCCESSFUL", 
-                "UNSUCCESSFUL", 
-                "FAILED", 
-                "ABORTED", 
-                "TIMED_OUT", 
+                "SUCCESSFUL",
+                "UNSUCCESSFUL",
+                "FAILED",
+                "ABORTED",
+                "TIMED_OUT",
                 "INCONCLUSIVE"
               ]
             },

--- a/schemas/EiffelActivityStartedEvent.json
+++ b/schemas/EiffelActivityStartedEvent.json
@@ -9,7 +9,8 @@
           "type": "string"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "enum": ["EiffelActivityStartedEvent"]
         },
         "version": {
           "type": "string",

--- a/schemas/EiffelActivityTriggeredEvent.json
+++ b/schemas/EiffelActivityTriggeredEvent.json
@@ -9,7 +9,8 @@
           "type": "string"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "enum": ["EiffelTriggeredFinishedEvent"]
         },
         "version": {
           "type": "string",

--- a/schemas/EiffelActivityTriggeredEvent.json
+++ b/schemas/EiffelActivityTriggeredEvent.json
@@ -10,7 +10,7 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelTriggeredFinishedEvent"]
+          "enum": ["EiffelActivityTriggeredEvent"]
         },
         "version": {
           "type": "string",

--- a/schemas/EiffelArtifactCreatedEvent.json
+++ b/schemas/EiffelArtifactCreatedEvent.json
@@ -9,7 +9,8 @@
           "type": "string"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "enum": ["EiffelArtifactCreatedEvent"]
         },
         "version": {
           "type": "string",
@@ -124,8 +125,8 @@
           "type": "string",
           "enum": [
             "NONE",
-            "ANY", 
-            "EXACTLY_ONE", 
+            "ANY",
+            "EXACTLY_ONE",
             "AT_LEAST_ONE"
           ]
         },

--- a/schemas/EiffelArtifactPublishedEvent.json
+++ b/schemas/EiffelArtifactPublishedEvent.json
@@ -9,7 +9,8 @@
           "type": "string"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "enum": ["EiffelArtifactPublishedEvent"]
         },
         "version": {
           "type": "string",
@@ -86,9 +87,9 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "ARTIFACTORY", 
-                  "NEXUS", 
-                  "PLAIN", 
+                  "ARTIFACTORY",
+                  "NEXUS",
+                  "PLAIN",
                   "OTHER"
                 ]
               },

--- a/schemas/EiffelConfidenceLevelModifiedEvent.json
+++ b/schemas/EiffelConfidenceLevelModifiedEvent.json
@@ -9,7 +9,8 @@
           "type": "string"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "enum": ["EiffelConfidenceLevelModifiedEvent"]
         },
         "version": {
           "type": "string",


### PR DESCRIPTION
Since each event is described in a separate schema, the particular meta.type string should be specified, i.e. an EiffelActivityCanceled event is only valid iff meta.type == "EiffelActivityCanceledEvent".