### PR TITLE
Made schemas version specific

### DIFF
--- a/examples/validate.py
+++ b/examples/validate.py
@@ -30,14 +30,18 @@ def loadSchemas():
   schemaTuples, badSchemaFiles = loadAllJsonObjects("schemas")
   schemas = {}
   for path, fileName, o in schemaTuples:
-    schemas[fileName[:-5]] = o
+    schemaName = os.path.basename(os.path.dirname(path))
+    versionName = fileName[:-5]
+    schemas[schemaName + "-" + versionName] = o
+  
   return schemas, badSchemaFiles
     
 def loadExamples():
   exampleTuples, badExampleFiles = loadAllJsonObjects("examples")
   examples = []
   for path, fileName, o in exampleTuples:
-    examples.append((path, o["meta"]["type"], o["meta"]["id"], o))
+    examples.append((path, o["meta"]["type"], o["meta"]["version"], o["meta"]["id"], o))
+
   return examples, badExampleFiles
     
 def validateExamples(examples, schemas):
@@ -45,10 +49,11 @@ def validateExamples(examples, schemas):
   numberOfSuccessfulValidations = 0
   unchecked = []
   
-  for path, type, id, json in examples:
-    if type in schemas:
+  for path, type, version, id, json in examples:
+    schemaKey = type + "-" + version
+    if schemaKey in schemas:
       try:
-        validate(json, schemas[type])
+        validate(json, schemas[schemaKey])
         numberOfSuccessfulValidations += 1
       except Exception as e:
         failures.append((path, type, id, e))

--- a/schemas/EiffelActivityCanceledEvent/1.0.0.json
+++ b/schemas/EiffelActivityCanceledEvent/1.0.0.json
@@ -1,4 +1,4 @@
-{
+ {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
@@ -10,11 +10,12 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelConfidenceLevelModifiedEvent"]
+          "enum": ["EiffelActivityCanceledEvent"]
         },
         "version": {
           "type": "string",
-          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
+          "enum": [ "1.0.0" ],
+          "default": "1.0.0"
         },
         "time": {
           "type": "integer"
@@ -79,30 +80,8 @@
     "data": {
       "type": "object",
       "properties": {
-        "name": {
+        "reason": {
           "type": "string"
-        },
-        "value": {
-          "type": "string",
-          "enum": ["SUCCESS", "FAILURE", "INCONCLUSIVE"]
-        },
-        "issuer": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "email": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "group": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
         },
         "customData": {
           "type": "array",
@@ -123,10 +102,6 @@
           }
         }
       },
-      "required": [
-        "name",
-        "value"
-      ],
       "additionalProperties": false
     },
     "links": {
@@ -154,5 +129,5 @@
     "data",
     "links"
   ],
-  "additionalProperties": false
+  "additonalProperties": false
 }

--- a/schemas/EiffelActivityCanceledEvent/1.0.0.json
+++ b/schemas/EiffelActivityCanceledEvent/1.0.0.json
@@ -1,4 +1,4 @@
- {
+{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {

--- a/schemas/EiffelActivityFinishedEvent/1.0.0.json
+++ b/schemas/EiffelActivityFinishedEvent/1.0.0.json
@@ -10,11 +10,12 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityStartedEvent"]
+          "enum": ["EiffelActivityFinishedEvent"]
         },
         "version": {
           "type": "string",
-          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
+          "enum": [ "1.0.0" ],
+          "default": "1.0.0"
         },
         "time": {
           "type": "integer"
@@ -79,10 +80,29 @@
     "data": {
       "type": "object",
       "properties": {
-        "executionUri": {
-          "type": "string"
+        "outcome": {
+          "type": "object",
+          "properties": {
+            "conclusion": {
+              "type": "string",
+              "enum": [
+                "SUCCESSFUL",
+                "UNSUCCESSFUL",
+                "FAILED",
+                "ABORTED",
+                "TIMED_OUT",
+                "INCONCLUSIVE"
+              ]
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "conclusion"
+          ]
         },
-        "liveLogs": {
+        "persistentLogs": {
           "type": "array",
           "items": {
             "type": "object",
@@ -120,7 +140,10 @@
           }
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "outcome"
+      ]
     },
     "links": {
       "type": "array",

--- a/schemas/EiffelActivityStartedEvent/1.0.0.json
+++ b/schemas/EiffelActivityStartedEvent/1.0.0.json
@@ -10,11 +10,12 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityFinishedEvent"]
+          "enum": ["EiffelActivityStartedEvent"]
         },
         "version": {
           "type": "string",
-          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
+          "enum": [ "1.0.0" ],
+          "default": "1.0.0"
         },
         "time": {
           "type": "integer"
@@ -79,29 +80,10 @@
     "data": {
       "type": "object",
       "properties": {
-        "outcome": {
-          "type": "object",
-          "properties": {
-            "conclusion": {
-              "type": "string",
-              "enum": [
-                "SUCCESSFUL",
-                "UNSUCCESSFUL",
-                "FAILED",
-                "ABORTED",
-                "TIMED_OUT",
-                "INCONCLUSIVE"
-              ]
-            },
-            "description": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "conclusion"
-          ]
+        "executionUri": {
+          "type": "string"
         },
-        "persistentLogs": {
+        "liveLogs": {
           "type": "array",
           "items": {
             "type": "object",
@@ -139,10 +121,7 @@
           }
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "outcome"
-      ]
+      "additionalProperties": false
     },
     "links": {
       "type": "array",

--- a/schemas/EiffelActivityTriggeredEvent/1.0.0.json
+++ b/schemas/EiffelActivityTriggeredEvent/1.0.0.json
@@ -10,11 +10,12 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactPublishedEvent"]
+          "enum": ["EiffelActivityTriggeredEvent"]
         },
         "version": {
           "type": "string",
-          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
+          "enum": [ "1.0.0" ],
+          "default": "1.0.0"
         },
         "time": {
           "type": "integer"
@@ -79,30 +80,35 @@
     "data": {
       "type": "object",
       "properties": {
-        "locations": {
+        "name": {
+          "type": "string"
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "triggers": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "type": {
-                "type": "string",
-                "enum": [
-                  "ARTIFACTORY",
-                  "NEXUS",
-                  "PLAIN",
-                  "OTHER"
-                ]
+                "type": "string"
               },
-              "uri": {
+              "description": {
                 "type": "string"
               }
             },
             "required": [
-              "type",
-              "uri"
+              "type"
             ],
             "additionalProperties": false
           }
+        },
+        "executionType": {
+          "type": "string"
         },
         "customData": {
           "type": "array",
@@ -124,7 +130,7 @@
         }
       },
       "required": [
-        "locations"
+        "name"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelArtifactCreatedEvent/1.0.0.json
+++ b/schemas/EiffelArtifactCreatedEvent/1.0.0.json
@@ -10,11 +10,12 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityCanceledEvent"]
+          "enum": ["EiffelArtifactCreatedEvent"]
         },
         "version": {
           "type": "string",
-          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
+          "enum": [ "1.0.0" ],
+          "default": "1.0.0"
         },
         "time": {
           "type": "integer"
@@ -79,8 +80,102 @@
     "data": {
       "type": "object",
       "properties": {
-        "reason": {
+        "gav": {
+          "type": "object",
+          "properties": {
+            "groupId": {
+              "type": "string"
+            },
+            "artifactId": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "groupId",
+            "artifactId",
+            "version"
+          ],
+          "additionalProperties": false
+        },
+        "fileInformation": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "classifier": {
+                "type": "string"
+              },
+              "extension": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "classifier",
+              "extension"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "buildCommand": {
           "type": "string"
+        },
+        "requiresImplementation": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "ANY",
+            "EXACTLY_ONE",
+            "AT_LEAST_ONE"
+          ]
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "groupId": {
+                "type": "string"
+              },
+              "artifactId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "groupId",
+              "artifactId",
+              "version"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "implements": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "groupId": {
+                "type": "string"
+              },
+              "artifactId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "groupId",
+              "artifactId",
+              "version"
+            ],
+            "additionalProperties": false
+          }
         },
         "customData": {
           "type": "array",
@@ -101,6 +196,9 @@
           }
         }
       },
+      "required": [
+        "gav"
+      ],
       "additionalProperties": false
     },
     "links": {
@@ -128,5 +226,5 @@
     "data",
     "links"
   ],
-  "additonalProperties": false
+  "additionalProperties": false
 }

--- a/schemas/EiffelArtifactPublishedEvent/1.0.0.json
+++ b/schemas/EiffelArtifactPublishedEvent/1.0.0.json
@@ -10,11 +10,12 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactCreatedEvent"]
+          "enum": ["EiffelArtifactPublishedEvent"]
         },
         "version": {
           "type": "string",
-          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
+          "enum": [ "1.0.0" ],
+          "default": "1.0.0"
         },
         "time": {
           "type": "integer"
@@ -79,99 +80,27 @@
     "data": {
       "type": "object",
       "properties": {
-        "gav": {
-          "type": "object",
-          "properties": {
-            "groupId": {
-              "type": "string"
-            },
-            "artifactId": {
-              "type": "string"
-            },
-            "version": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "groupId",
-            "artifactId",
-            "version"
-          ],
-          "additionalProperties": false
-        },
-        "fileInformation": {
+        "locations": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "classifier": {
-                "type": "string"
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ARTIFACTORY",
+                  "NEXUS",
+                  "PLAIN",
+                  "OTHER"
+                ]
               },
-              "extension": {
+              "uri": {
                 "type": "string"
               }
             },
             "required": [
-              "classifier",
-              "extension"
-            ],
-            "additionalProperties": false
-          }
-        },
-        "buildCommand": {
-          "type": "string"
-        },
-        "requiresImplementation": {
-          "type": "string",
-          "enum": [
-            "NONE",
-            "ANY",
-            "EXACTLY_ONE",
-            "AT_LEAST_ONE"
-          ]
-        },
-        "dependsOn": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "groupId": {
-                "type": "string"
-              },
-              "artifactId": {
-                "type": "string"
-              },
-              "version": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "groupId",
-              "artifactId",
-              "version"
-            ],
-            "additionalProperties": false
-          }
-        },
-        "implements": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "groupId": {
-                "type": "string"
-              },
-              "artifactId": {
-                "type": "string"
-              },
-              "version": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "groupId",
-              "artifactId",
-              "version"
+              "type",
+              "uri"
             ],
             "additionalProperties": false
           }
@@ -196,7 +125,7 @@
         }
       },
       "required": [
-        "gav"
+        "locations"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelConfidenceLevelModifiedEvent/1.0.0.json
+++ b/schemas/EiffelConfidenceLevelModifiedEvent/1.0.0.json
@@ -10,11 +10,12 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityTriggeredEvent"]
+          "enum": ["EiffelConfidenceLevelModifiedEvent"]
         },
         "version": {
           "type": "string",
-          "pattern": "^(\\d+\\.)(\\d+\\.)(\\d+)$"
+          "enum": [ "1.0.0" ],
+          "default": "1.0.0"
         },
         "time": {
           "type": "integer"
@@ -82,32 +83,27 @@
         "name": {
           "type": "string"
         },
-        "categories": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "value": {
+          "type": "string",
+          "enum": ["SUCCESS", "FAILURE", "INCONCLUSIVE"]
         },
-        "triggers": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string"
-              },
-              "description": {
-                "type": "string"
-              }
+        "issuer": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
             },
-            "required": [
-              "type"
-            ],
-            "additionalProperties": false
-          }
-        },
-        "executionType": {
-          "type": "string"
+            "email": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         },
         "customData": {
           "type": "array",
@@ -129,7 +125,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "value"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
As per issue #76, made each schema check the value of meta.version.
Consequently, each schema is now version specific. The directory
structure of schemas has been changed accordingly, and the
validation script now looks for a schema not just based on the
event type, but also based on the event version.