### PR TITLE
Made meta.source and meta.source.domainId optional

### DIFF
--- a/eiffel-syntax-and-usage/the-meta-object.md
+++ b/eiffel-syntax-and-usage/the-meta-object.md
@@ -35,13 +35,13 @@ __Description:__ Any tags or keywords associated with the events, for searchabil
 ### meta.source
 __Type:__ Object  
 __Format:__  
-__Required:__ Yes  
-__Description:__ A description of the event sender. Primarily for traceability purposes.
+__Required:__ No  
+__Description:__ A description of the source of the event. This object is primarily for traceability purposes, and while optional, some form of identification of the source is __HIGHLY RECOMMENDED__. It offers multiple methods of identifying the source of the event, techniques which may be select from based on the technology domain and needs in any particular use case.
 
 #### meta.source.domainId
 __Type:__ String  
 __Format:__ Free text  
-__Required:__ Yes  
+__Required:__ No  
 __Description:__ Identifies the domain that produced an event. A domain is an infrastructure topological concept, which may or may not corresponds to an organization or product structures. A good example would be Java packages notation, ex. com.mycompany.product.component or mycompany.site.division. Also, keep in mind that all names are more or less prone to change. Particularly, it is recommended to avoid organizational names or site names, as organizations tend to be volatile and development is easily relocated. Relatively speaking, product and component names tend to be more stable and are therefore encouraged, while code names may be an option. You need to decide what is the most sensible option in your case.
 
 #### meta.source.host

--- a/examples/events/EiffelActivityCanceledEvent/simple.json
+++ b/examples/events/EiffelActivityCanceledEvent/simple.json
@@ -3,10 +3,7 @@
     "type": "EiffelActivityCanceledEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
-    "source": {
-      "domainId": "example.domain"
-    }
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "reason": "Made irrelevant by newly scheduled execution."

--- a/examples/events/EiffelActivityFinishedEvent/simple.json
+++ b/examples/events/EiffelActivityFinishedEvent/simple.json
@@ -3,10 +3,7 @@
     "type": "EiffelActivityFinishedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
-    "source": {
-      "domainId": "example.domain"
-    }
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "outcome": {

--- a/examples/events/EiffelActivityStartedEvent/simple.json
+++ b/examples/events/EiffelActivityStartedEvent/simple.json
@@ -3,10 +3,7 @@
     "type": "EiffelActivityStartedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
-    "source": {
-      "domainId": "example.domain"
-    }
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "executionUri": "https://my.jenkins.host/myJob/43",

--- a/examples/events/EiffelActivityTriggeredEvent/simple.json
+++ b/examples/events/EiffelActivityTriggeredEvent/simple.json
@@ -3,10 +3,7 @@
     "id": "e1e93f13-7c3c-4f17-9753-ebf0c86ff1c2",
     "type": "EiffelActivityTriggeredEvent",
     "version": "1.0.0",
-    "time": 1234567890,
-    "source": {
-      "domainId": "example.domain"
-    }
+    "time": 1234567890
   },
   "data": {
     "name": "Component X Build",

--- a/examples/events/EiffelAnnouncementPublishedEvent/simple.json
+++ b/examples/events/EiffelAnnouncementPublishedEvent/simple.json
@@ -3,9 +3,6 @@
     "type": "EiffelAnnouncementPublishedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "source": {
-      "domainId": "example.domain"
-    },
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {

--- a/examples/events/EiffelArtifactCreatedEvent/backend.json
+++ b/examples/events/EiffelArtifactCreatedEvent/backend.json
@@ -4,7 +4,6 @@
     "version": "1.0.0",
     "time": 1234567890,
     "source": {
-      "domainId": "example.domain"
     },
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelArtifactCreatedEvent/dependent.json
+++ b/examples/events/EiffelArtifactCreatedEvent/dependent.json
@@ -4,7 +4,7 @@
     "version": "1.0.0",
     "time": 1234567890,
     "source": {
-      "domainId": "example.domain"
+      "uri": "https://ci.internal.myorg.org/ArtifactBuilder/info"
     },
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelArtifactCreatedEvent/interface.json
+++ b/examples/events/EiffelArtifactCreatedEvent/interface.json
@@ -4,7 +4,11 @@
     "version": "1.0.0",
     "time": 1234567890,
     "source": {
-      "domainId": "example.domain"
+      "serializer": {
+        "groupId": "com.mycompany.pipeline-tools",
+        "artifactId": "eiffel-serializer",
+        "version": "57"
+      }
     },
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelArtifactCreatedEvent/simple.json
+++ b/examples/events/EiffelArtifactCreatedEvent/simple.json
@@ -5,7 +5,6 @@
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {
-      "domainId": "example.domain",
       "serializer": {
         "groupId": "com.mycompany.tools",
         "artifactId": "eiffel-serializer",

--- a/examples/events/EiffelArtifactPublishedEvent/simple.json
+++ b/examples/events/EiffelArtifactPublishedEvent/simple.json
@@ -3,10 +3,7 @@
     "type": "EiffelArtifactPublishedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
-    "source": {
-      "domainId": "example.domain"
-    }
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "locations": [

--- a/examples/events/EiffelCompositionDefinedEvent/simple.json
+++ b/examples/events/EiffelCompositionDefinedEvent/simple.json
@@ -3,10 +3,7 @@
     "type": "EiffelCompositionDefinedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
-    "source": {
-      "domainId": "example.domain"
-    }
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "name": "myCompositionName",

--- a/examples/events/EiffelConfidenceLevelModifiedEvent/simple.json
+++ b/examples/events/EiffelConfidenceLevelModifiedEvent/simple.json
@@ -3,10 +3,7 @@
     "type": "EiffelConfidenceLevelModifiedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
-    "source": {
-      "domainId": "example.domain"
-    }
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "name": "stable",

--- a/examples/events/EiffelEnvironmentDefinedEvent/host.json
+++ b/examples/events/EiffelEnvironmentDefinedEvent/host.json
@@ -5,7 +5,7 @@
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {
-      "domainId": "example.domain"
+      "host": "envmanager.internal.myorg.org"
     }
   },
   "data": {

--- a/examples/events/EiffelEnvironmentDefinedEvent/image.json
+++ b/examples/events/EiffelEnvironmentDefinedEvent/image.json
@@ -3,10 +3,7 @@
     "type": "EiffelEnvironmentDefinedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
-    "source": {
-      "domainId": "example.domain"
-    }
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "name": "John's Docker Image",

--- a/examples/events/EiffelEnvironmentDefinedEvent/uri.json
+++ b/examples/events/EiffelEnvironmentDefinedEvent/uri.json
@@ -5,7 +5,7 @@
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
     "source": {
-      "domainId": "example.domain"
+      "name": "Environment Manager"
     }
   },
   "data": {

--- a/examples/events/EiffelFlowContextDefinedEvent/simple.json
+++ b/examples/events/EiffelFlowContextDefinedEvent/simple.json
@@ -3,9 +3,6 @@
     "type": "EiffelFlowContextDefinedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "source": {
-      "domainId": "example.domain"
-    },
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {

--- a/examples/events/EiffelIssueVerifiedEvent/simple.json
+++ b/examples/events/EiffelIssueVerifiedEvent/simple.json
@@ -3,10 +3,7 @@
     "type": "EiffelIssueVerifiedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
-    "source": {
-      "domainId": "example.domain"
-    }
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "issues": [

--- a/examples/events/EiffelSourceChangeCreatedEvent/simple.json
+++ b/examples/events/EiffelSourceChangeCreatedEvent/simple.json
@@ -3,10 +3,7 @@
     "type": "EiffelSourceChangeCreatedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
-    "source": {
-      "domainId": "example.domain"
-    }
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "gitIdentifier": {

--- a/examples/events/EiffelSourceChangeSubmittedEvent/simple.json
+++ b/examples/events/EiffelSourceChangeSubmittedEvent/simple.json
@@ -3,10 +3,7 @@
     "type": "EiffelSourceChangeSubmittedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
-    "source": {
-      "domainId": "example.domain"
-    }
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "svnIdentifier": {

--- a/examples/events/EiffelTestCaseFinishedEvent/simple.json
+++ b/examples/events/EiffelTestCaseFinishedEvent/simple.json
@@ -3,10 +3,7 @@
     "type": "EiffelTestCaseFinishedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
-    "source": {
-      "domainId": "example.domain"
-    }
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "outcome": {

--- a/examples/events/EiffelTestCaseStartedEvent/simple.json
+++ b/examples/events/EiffelTestCaseStartedEvent/simple.json
@@ -3,10 +3,7 @@
     "type": "EiffelTestCaseStartedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
-    "source": {
-      "domainId": "example.domain"
-    }
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "testCase": {

--- a/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches.json
+++ b/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches.json
@@ -3,9 +3,6 @@
     "type": "EiffelTestExecutionRecipeCollectionCreatedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "source": {
-      "domainId": "example.domain"
-    },
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {

--- a/examples/events/EiffelTestSuiteFinishedEvent/simple.json
+++ b/examples/events/EiffelTestSuiteFinishedEvent/simple.json
@@ -3,10 +3,7 @@
     "type": "EiffelTestSuiteFinishedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
-    "source": {
-      "domainId": "example.domain"
-    }
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "outcome": {

--- a/examples/events/EiffelTestSuiteStartedEvent/simple.json
+++ b/examples/events/EiffelTestSuiteStartedEvent/simple.json
@@ -3,9 +3,6 @@
     "type": "EiffelTestSuiteStartedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "source": {
-      "domainId": "example.domain"
-    },
     "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {

--- a/schemas/EiffelActivityCanceledEvent/1.0.0.json
+++ b/schemas/EiffelActivityCanceledEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelActivityFinishedEvent/1.0.0.json
+++ b/schemas/EiffelActivityFinishedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelActivityStartedEvent/1.0.0.json
+++ b/schemas/EiffelActivityStartedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelActivityTriggeredEvent/1.0.0.json
+++ b/schemas/EiffelActivityTriggeredEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelAnnouncementPublishedEvent/1.0.0.json
+++ b/schemas/EiffelAnnouncementPublishedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelArtifactCreatedEvent/1.0.0.json
+++ b/schemas/EiffelArtifactCreatedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelArtifactPublishedEvent/1.0.0.json
+++ b/schemas/EiffelArtifactPublishedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelArtifactReusedEvent/1.0.0.json
+++ b/schemas/EiffelArtifactReusedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelCompositionDefinedEvent/1.0.0.json
+++ b/schemas/EiffelCompositionDefinedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelConfidenceLevelModifiedEvent/1.0.0.json
+++ b/schemas/EiffelConfidenceLevelModifiedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelEnvironmentDefinedEvent/1.0.0.json
+++ b/schemas/EiffelEnvironmentDefinedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelFlowContextDefinedEvent/1.0.0.json
+++ b/schemas/EiffelFlowContextDefinedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelIssueVerifiedEvent/1.0.0.json
+++ b/schemas/EiffelIssueVerifiedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelSourceChangeCreatedEvent/1.0.0.json
+++ b/schemas/EiffelSourceChangeCreatedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelSourceChangeSubmittedEvent/1.0.0.json
+++ b/schemas/EiffelSourceChangeSubmittedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelTestCaseFinishedEvent/1.0.0.json
+++ b/schemas/EiffelTestCaseFinishedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelTestCaseStartedEvent/1.0.0.json
+++ b/schemas/EiffelTestCaseStartedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.json
+++ b/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelTestSuiteFinishedEvent/1.0.0.json
+++ b/schemas/EiffelTestSuiteFinishedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },

--- a/schemas/EiffelTestSuiteStartedEvent/1.0.0.json
+++ b/schemas/EiffelTestSuiteStartedEvent/1.0.0.json
@@ -62,9 +62,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "domainId"
-          ],
           "additionalProperties": false
         }
       },
@@ -72,8 +69,7 @@
         "id",
         "type",
         "version",
-        "time",
-        "source"
+        "time"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
As per issue #113. Also removed meta.source from the majority
of examples. In cases where there are multiple examples of the
same event, these were changed so that various forms of expressing
meta.source are exemplified.