### PR TITLE
Simplified json schemas by breaking out common definitions

### DIFF
--- a/schemas/Definitions/1.0.0.json
+++ b/schemas/Definitions/1.0.0.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "definitions": {
+    "meta": {
+      "source": {
+        "type": "object",
+        "properties": {
+          "domainId": {
+            "type": "string"
+          },
+          "host": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "serializer": {
+            "type": "object",
+            "properties": {
+              "groupId": {
+                "type": "string"
+              },
+              "artifactId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "groupId",
+              "artifactId",
+              "version"
+            ],
+            "additionalProperties": false
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "data": {
+      "testCase": {
+        "type": "object",
+        "properties": {
+          "tracker": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/schemas/EiffelActivityCanceledEvent/1.0.0.json
+++ b/schemas/EiffelActivityCanceledEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityCanceledEvent"]
+          "enum": [
+            "EiffelActivityCanceledEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -101,23 +70,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelActivityFinishedEvent/1.0.0.json
+++ b/schemas/EiffelActivityFinishedEvent/1.0.0.json
@@ -27,42 +27,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -142,23 +107,7 @@
       ]
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelActivityStartedEvent/1.0.0.json
+++ b/schemas/EiffelActivityStartedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityStartedEvent"]
+          "enum": [
+            "EiffelActivityStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -120,23 +89,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelActivityTriggeredEvent/1.0.0.json
+++ b/schemas/EiffelActivityTriggeredEvent/1.0.0.json
@@ -27,42 +27,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -131,23 +96,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelAnnouncementPublishedEvent/1.0.0.json
+++ b/schemas/EiffelAnnouncementPublishedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelAnnouncementPublishedEvent" ]
+          "enum": [
+            "EiffelAnnouncementPublishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -87,7 +56,14 @@
         },
         "severity": {
           "type": "string",
-          "enum": ["MINOR", "MAJOR", "CRITICAL", "BLOCKER", "CLOSED", "CANCELED"]
+          "enum": [
+            "MINOR",
+            "MAJOR",
+            "CRITICAL",
+            "BLOCKER",
+            "CLOSED",
+            "CANCELED"
+          ]
         },
         "customData": {
           "type": "array",
@@ -116,23 +92,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelArtifactCreatedEvent/1.0.0.json
+++ b/schemas/EiffelArtifactCreatedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactCreatedEvent"]
+          "enum": [
+            "EiffelArtifactCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -201,23 +170,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelArtifactPublishedEvent/1.0.0.json
+++ b/schemas/EiffelArtifactPublishedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactPublishedEvent"]
+          "enum": [
+            "EiffelArtifactPublishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -126,23 +95,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelArtifactReusedEvent/1.0.0.json
+++ b/schemas/EiffelArtifactReusedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelArtifactReusedEvent" ]
+          "enum": [
+            "EiffelArtifactReusedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -98,23 +67,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelCompositionDefinedEvent/1.0.0.json
+++ b/schemas/EiffelCompositionDefinedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelCompositionDefinedEvent" ]
+          "enum": [
+            "EiffelCompositionDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -107,23 +76,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelConfidenceLevelModifiedEvent/1.0.0.json
+++ b/schemas/EiffelConfidenceLevelModifiedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelConfidenceLevelModifiedEvent"]
+          "enum": [
+            "EiffelConfidenceLevelModifiedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -81,7 +50,11 @@
         },
         "value": {
           "type": "string",
-          "enum": ["SUCCESS", "FAILURE", "INCONCLUSIVE"]
+          "enum": [
+            "SUCCESS",
+            "FAILURE",
+            "INCONCLUSIVE"
+          ]
         },
         "issuer": {
           "type": "object",
@@ -127,23 +100,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelEnvironmentDefinedEvent/1.0.0.json
+++ b/schemas/EiffelEnvironmentDefinedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelEnvironmentDefinedEvent" ]
+          "enum": [
+            "EiffelEnvironmentDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -129,23 +98,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelFlowContextDefinedEvent/1.0.0.json
+++ b/schemas/EiffelFlowContextDefinedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelFlowContextDefinedEvent" ]
+          "enum": [
+            "EiffelFlowContextDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -113,23 +82,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelIssueVerifiedEvent/1.0.0.json
+++ b/schemas/EiffelIssueVerifiedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelIssueVerifiedEvent" ]
+          "enum": [
+            "EiffelIssueVerifiedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -145,23 +114,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelSourceChangeCreatedEvent/1.0.0.json
+++ b/schemas/EiffelSourceChangeCreatedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelSourceChangeCreatedEvent" ]
+          "enum": [
+            "EiffelSourceChangeCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -273,23 +242,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelSourceChangeSubmittedEvent/1.0.0.json
+++ b/schemas/EiffelSourceChangeSubmittedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelSourceChangeSubmittedEvent" ]
+          "enum": [
+            "EiffelSourceChangeSubmittedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -206,23 +175,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelTestCaseFinishedEvent/1.0.0.json
+++ b/schemas/EiffelTestCaseFinishedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseFinishedEvent" ]
+          "enum": [
+            "EiffelTestCaseFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -169,23 +138,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelTestCaseStartedEvent/1.0.0.json
+++ b/schemas/EiffelTestCaseStartedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseStartedEvent" ]
+          "enum": [
+            "EiffelTestCaseStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -77,22 +46,7 @@
       "type": "object",
       "properties": {
         "testCase": {
-          "type": "object",
-          "properties": {
-            "tracker": {
-              "type": "string"
-            },
-            "id": {
-              "type": "string"
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "id"
-          ],
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/data/testCase"
         },
         "executor": {
           "type": "string"
@@ -172,23 +126,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.json
+++ b/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestExecutionRecipeCollectionCreatedEvent" ]
+          "enum": [
+            "EiffelTestExecutionRecipeCollectionCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -118,22 +87,7 @@
                       "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
                     },
                     "testCase": {
-                      "type": "object",
-                      "properties": {
-                        "tracker": {
-                          "type": "string"
-                        },
-                        "id": {
-                          "type": "string"
-                        },
-                        "uri": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "id"
-                      ],
-                      "additionalProperties": false
+                      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/data/testCase"
                     },
                     "constraints": {
                       "type": "object"
@@ -199,23 +153,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelTestSuiteFinishedEvent/1.0.0.json
+++ b/schemas/EiffelTestSuiteFinishedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteFinishedEvent" ]
+          "enum": [
+            "EiffelTestSuiteFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -144,23 +113,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [

--- a/schemas/EiffelTestSuiteStartedEvent/1.0.0.json
+++ b/schemas/EiffelTestSuiteStartedEvent/1.0.0.json
@@ -10,11 +10,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteStartedEvent" ]
+          "enum": [
+            "EiffelTestSuiteStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -27,42 +31,7 @@
           }
         },
         "source": {
-          "type": "object",
-          "properties": {
-            "domainId": {
-              "type": "string"
-            },
-            "host": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "serializer": {
-              "type": "object",
-              "properties": {
-                "groupId": {
-                  "type": "string"
-                },
-                "artifactId": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "groupId",
-                "artifactId",
-                "version"
-              ],
-              "additionalProperties": false
-            },
-            "uri": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/meta/source"
         }
       },
       "required": [
@@ -154,23 +123,7 @@
       "additionalProperties": false
     },
     "links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "target": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "target"
-        ],
-        "additionalProperties": false
-      }
+      "$ref": "file:schemas/Definitions/1.0.0.json#/definitions/links"
     }
   },
   "required": [


### PR DESCRIPTION
Created a common definitions schema in schemas/Definitions.

Referenced some common definitions from the other schemas to that one.

I needed to instantiate a local RefResolver to be able to use a custom uri handler which was needed to be able to use relative file paths in the schema refs.