### PR TITLE
Updated versioning information in preparation of edition-bordeaux

### DIFF
--- a/eiffel-syntax-and-usage/versioning.md
+++ b/eiffel-syntax-and-usage/versioning.md
@@ -24,12 +24,12 @@ The independent versioning of event types, as opposed to a protocol-wide version
 
 That being said, to facilitate compatibility and consistency, the Eiffel protocol as described in this repository is released in named and internally coherent _editions_. Each of these editions is represented as a GitHub [release](https://github.com/Ericsson/eiffel/releases). A history of Eiffel editions is available below.
 
-| Edition   | Tag |
-| --------- | ------------------ |
-| Arica  | _Reserved for future use._  |
-| Lyon  | _Reserved for future use._  |
-| Paris  | _Reserved for future use._  |
-| Agen  | _Reserved for future use._  |
-| Toulouse  | _Reserved for future use._  |
-| Bordeaux  | [edition-bordeaux](../../../tree/edition-bordeaux)  |
+| Edition   | Tag                                                 | Changes                                          |
+| --------- | --------------------------------------------------- | ------------------------------------------------ |
+| Arica  | _Reserved for future use._  | |
+| Lyon  | _Reserved for future use._  | |
+| Paris  | _Reserved for future use._  | |
+| Agen  | _Reserved for future use._  | |
+| Toulouse  | _Reserved for future use._  | |
+| Bordeaux  | [edition-bordeaux](../../../tree/edition-bordeaux)  | Initial edition. |
 

--- a/eiffel-syntax-and-usage/versioning.md
+++ b/eiffel-syntax-and-usage/versioning.md
@@ -26,5 +26,10 @@ That being said, to facilitate compatibility and consistency, the Eiffel protoco
 
 | Edition   | Tag |
 | --------- | ------------------ |
-| Bordeaux  | _First edition. Not yet finished. Planned for end of [Drop 4](https://github.com/Ericsson/eiffel/milestone/4)._  |
+| Arica  | _Reserved for future use._  |
+| Lyon  | _Reserved for future use._  |
+| Paris  | _Reserved for future use._  |
+| Agen  | _Reserved for future use._  |
+| Toulouse  | _Reserved for future use._  |
+| Bordeaux  | [edition-bordeaux](../../../tree/edition-bordeaux)  |
 

--- a/eiffel-vocabulary/EiffelActivityCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelActivityCanceledEvent.md
@@ -25,9 +25,9 @@ __Required:__ No
 __Description:__ Any human readable information as to the reason for dequeueing.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelActivityCanceledEvent/simple.json)

--- a/eiffel-vocabulary/EiffelActivityFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityFinishedEvent.md
@@ -57,9 +57,9 @@ __Required:__ Yes
 __Description:__ The URI at which the log can be retrieved.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelActivityFinishedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelActivityStartedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityStartedEvent.md
@@ -40,9 +40,9 @@ __Required:__ Yes
 __Description:__ The URI at which the log can be retrieved.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelActivityStartedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
@@ -59,9 +59,9 @@ __Legal values:__ MANUAL, SEMI_AUTOMATED, AUTOMATED, OTHER
 __Description:__ The type of execution (often related to, but ultimately separate from, __data.triggers.type__).
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelActivityTriggeredEvent/simple.json)

--- a/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md
@@ -41,9 +41,9 @@ __Legal values:__ MINOR, MAJOR, CRITICAL, BLOCKER, CLOSED, CANCELED
 __Description:__ The severity of the announcement. The CLOSED and CANCELED values SHOULD only be used when following up a previous announcement, i.e. in conjunction with a __MODIFIED_ANNOUNCEMENT__ link.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelAnnouncementPublishedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
@@ -115,9 +115,9 @@ __Required:__ No
 __Description:__ Any (colloquial) name of the artifact. Unlike __data.gav__, this is not intended as an unambiguous identifier of the artifact, but as a descriptive and human readable name.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelArtifactCreatedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
@@ -40,9 +40,9 @@ __Required:__ Yes
 __Description:__ The URI at which the artifact can be retrieved.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelArtifactPublishedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelArtifactReusedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactReusedEvent.md
@@ -23,9 +23,9 @@ The event has no data members, but solely relies on its two required link types 
 ## Data Members
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelArtifactReusedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
@@ -30,9 +30,9 @@ __Required:__ No
 __Description:__ The version of the composition, if any. This is in a sense redundant, as relationships between compositions can be tracked via the __PREVIOUS_VERSION__ link type, but can be used for improved clarity and semantics.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelCompositionDefinedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
+++ b/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
@@ -61,9 +61,9 @@ __Required:__ No
 __Description:__ Any group, such as a development team, committee or test group, to which the issuer belongs.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelConfidenceLevelModifiedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
@@ -57,9 +57,9 @@ __Required:__ No
 __Description:__ A URI identifying the environment description. This is the catch-all method of environment descriptions. Eiffel does not concern itself with the format or nature of the description, but merely points to its location.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [URI example](../examples/events/EiffelEnvironmentDefinedEvent/uri.json)

--- a/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
@@ -47,9 +47,9 @@ __Required:__ No
 __Description:__ A version context which other events can relate to. This member SHOULD be used in tandem with one of the other optional members - a version by itself is not very informative.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelFlowContextDefinedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelIssueVerifiedEvent.md
+++ b/eiffel-vocabulary/EiffelIssueVerifiedEvent.md
@@ -55,9 +55,9 @@ FAILURE signifies that verification of the issue failed.
 INCONCLUSIVE signifies that the verification of the issue was inconclusive.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelIssueVerifiedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
@@ -209,9 +209,9 @@ __Required:__ Yes
 __Description:__ The URI of the repo.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelSourceChangeCreatedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
@@ -144,9 +144,9 @@ __Required:__ Yes
 __Description:__ The URI of the repo.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelSourceChangeSubmittedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md
@@ -25,9 +25,9 @@ __Required:__ No
 __Description:__ Any human readable information as to the reason for dequeueing.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelTestCaseCanceledEvent/simple.json)

--- a/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
@@ -84,9 +84,9 @@ __Required:__ Yes
 __Description:__ The URI at which the log can be retrieved.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelTestCaseFinishedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
@@ -40,9 +40,9 @@ __Required:__ Yes
 __Description:__ The URI at which the log can be retrieved.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelTestCaseStartedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md
@@ -94,9 +94,9 @@ __Required:__ Yes
 __Description:__ The value of the parameter.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelTestCaseTriggeredEvent/simple.json)

--- a/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
@@ -118,9 +118,9 @@ __Required:__ Yes
 __Description:__ The UUID of the dependent execution (__data.batches.recipes.id__), i.e. the execution that shall be performed only after that of the dependency.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Example using data.batches](../examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches.json)

--- a/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
@@ -67,9 +67,9 @@ __Required:__ Yes
 __Description:__ The URI at which the log can be retrieved.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelTestSuiteFinishedEvent/simple.json)

--- a/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
@@ -53,9 +53,9 @@ __Required:__ Yes
 __Description:__ The URI at which the log can be retrieved.
 
 ## Version History
-| Version   | Introducing Commit |
-| --------- | ------------------ |
-| 1.0.0     | _Current version_  |
+| Version   | Introduced in                                          | Changes                                 |
+| --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Simple example](../examples/events/EiffelTestSuiteStartedEvent/simple.json)


### PR DESCRIPTION
Version tables in versioning.md and in individual event type definitions was updated for edition-bordeaux. Also added a Changes column to the version tables, to allow description of changes from version to version, both on a protocol edition level and on an individual event level.