### PR TITLE
Added schema validation of UUID syntax for meta.id and links.target

### DIFF
--- a/examples/events/EiffelActivityCanceledEvent/simple.json
+++ b/examples/events/EiffelActivityCanceledEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelActivityCanceledEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "reason": "Made irrelevant by newly scheduled execution."
@@ -11,11 +11,11 @@
   "links": [
     {
       "type": "ACTIVITY_EXECUTION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "CAUSE",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     }
 	]
 }

--- a/examples/events/EiffelActivityFinishedEvent/simple.json
+++ b/examples/events/EiffelActivityFinishedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelActivityFinishedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "outcome": {
@@ -24,7 +24,7 @@
   "links": [
     {
       "type": "ACTIVITY_EXECUTION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/events/EiffelActivityStartedEvent/simple.json
+++ b/examples/events/EiffelActivityStartedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelActivityStartedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "executionUri": "https://my.jenkins.host/myJob/43",
@@ -17,11 +17,11 @@
   "links": [
     {
       "type": "ACTIVITY_EXECUTION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "PREVIOUS_ACTIVITY_EXECUTION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     }
   ]
 }

--- a/examples/events/EiffelActivityTriggeredEvent/simple-customdata.json
+++ b/examples/events/EiffelActivityTriggeredEvent/simple-customdata.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "type": "EiffelActivityTriggeredEvent",
     "version": "1.0.0",
     "time": 1234567890,
@@ -34,7 +34,7 @@
   "links": [
     {
       "type": "CAUSE",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/events/EiffelActivityTriggeredEvent/simple.json
+++ b/examples/events/EiffelActivityTriggeredEvent/simple.json
@@ -21,7 +21,7 @@
   "links": [
     {
       "type": "CAUSE",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/events/EiffelAnnouncementPublishedEvent/simple.json
+++ b/examples/events/EiffelAnnouncementPublishedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelAnnouncementPublishedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "heading": "Serious incident",
@@ -14,11 +14,11 @@
   "links": [
     {
       "type": "MODIFIED_ANNOUNCEMENT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "FLOW_CONTEXT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     }
   ]
 }

--- a/examples/events/EiffelArtifactCreatedEvent/backend.json
+++ b/examples/events/EiffelArtifactCreatedEvent/backend.json
@@ -5,7 +5,7 @@
     "time": 1234567890,
     "source": {
     },
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "gav": {
@@ -31,19 +31,19 @@
   "links": [
     {
       "type": "CAUSE",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "PREVIOUS_VERSION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     },
     {
       "type": "COMPOSITION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "ENVIRONMENT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
     }
   ]
 }

--- a/examples/events/EiffelArtifactCreatedEvent/dependent.json
+++ b/examples/events/EiffelArtifactCreatedEvent/dependent.json
@@ -6,7 +6,7 @@
     "source": {
       "uri": "https://ci.internal.myorg.org/ArtifactBuilder/info"
     },
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "gav": {
@@ -32,19 +32,19 @@
   "links": [
     {
       "type": "CAUSE",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "PREVIOUS_VERSION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     },
     {
       "type": "COMPOSITION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "ENVIRONMENT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
     }
   ]
 }

--- a/examples/events/EiffelArtifactCreatedEvent/interface.json
+++ b/examples/events/EiffelArtifactCreatedEvent/interface.json
@@ -10,7 +10,7 @@
         "version": "57"
       }
     },
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "gav": {
@@ -30,19 +30,19 @@
   "links": [
     {
       "type": "CAUSE",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "PREVIOUS_VERSION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     },
     {
       "type": "COMPOSITION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "ENVIRONMENT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
     }
   ]
 }

--- a/examples/events/EiffelArtifactCreatedEvent/simple.json
+++ b/examples/events/EiffelArtifactCreatedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelArtifactCreatedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "source": {
       "serializer": {
         "groupId": "com.mycompany.tools",
@@ -11,7 +11,7 @@
         "version": "1.0.3"
       }
     },
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "tags": [
       "fast-track",
       "customer-a"
@@ -43,19 +43,19 @@
   "links": [
     {
       "type": "CAUSE",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "PREVIOUS_VERSION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     },
     {
       "type": "COMPOSITION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "ENVIRONMENT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
     }
   ]
 }

--- a/examples/events/EiffelArtifactPublishedEvent/simple.json
+++ b/examples/events/EiffelArtifactPublishedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelArtifactPublishedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "security": {
       "sdm": {
         "authorIdentity": "MyCompany/JohnDoe",
@@ -26,11 +26,11 @@
   "links": [
     {
       "type": "CONTEXT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "ARTIFACT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     }
   ]
 }

--- a/examples/events/EiffelArtifactReusedEvent/simple.json
+++ b/examples/events/EiffelArtifactReusedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelArtifactReusedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "source": {
       "domainId": "example.domain",
       "serializer": {
@@ -12,7 +12,7 @@
         "version": "1.0.3"
       }
     },
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "tags": [
       "fast-track",
       "customer-a"
@@ -23,15 +23,15 @@
   "links": [
     {
       "type": "CONTEXT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "REUSED_ARTIFACT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     },
     {
       "type": "COMPOSITION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
     }
   ]
 }

--- a/examples/events/EiffelCompositionDefinedEvent/simple.json
+++ b/examples/events/EiffelCompositionDefinedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelCompositionDefinedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "name": "myCompositionName",
@@ -12,23 +12,23 @@
   "links": [
     {
       "type": "ELEMENT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "ELEMENT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     },
     {
       "type": "ELEMENT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
     },
     {
       "type": "ELEMENT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
     },
     {
       "type": "PREVIOUS_VERSION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5"
     }
   ]
 }

--- a/examples/events/EiffelConfidenceLevelModifiedEvent/simple.json
+++ b/examples/events/EiffelConfidenceLevelModifiedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelConfidenceLevelModifiedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "name": "stable",
@@ -18,27 +18,27 @@
   "links": [
     {
       "type": "CAUSE",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "CAUSE",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     },
     {
       "type": "SUBJECT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
     },
     {
       "type": "SUBJECT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
     },
     {
       "type": "SUB_CONFIDENCE_LEVEL",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5"
     },
     {
       "type": "SUB_CONFIDENCE_LEVEL",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee6"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee6"
     }
   ]
 }

--- a/examples/events/EiffelEnvironmentDefinedEvent/host.json
+++ b/examples/events/EiffelEnvironmentDefinedEvent/host.json
@@ -3,7 +3,7 @@
     "type": "EiffelEnvironmentDefinedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "source": {
       "host": "envmanager.internal.myorg.org"
     }
@@ -19,7 +19,7 @@
   "links": [
     {
       "type": "PREVIOUS_VERSION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/events/EiffelEnvironmentDefinedEvent/image.json
+++ b/examples/events/EiffelEnvironmentDefinedEvent/image.json
@@ -3,7 +3,7 @@
     "type": "EiffelEnvironmentDefinedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "name": "John's Docker Image",
@@ -13,7 +13,7 @@
   "links": [
     {
       "type": "PREVIOUS_VERSION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/events/EiffelEnvironmentDefinedEvent/uri.json
+++ b/examples/events/EiffelEnvironmentDefinedEvent/uri.json
@@ -3,7 +3,7 @@
     "type": "EiffelEnvironmentDefinedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "source": {
       "name": "Environment Manager"
     }
@@ -16,7 +16,7 @@
   "links": [
     {
       "type": "PREVIOUS_VERSION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/events/EiffelFlowContextDefinedEvent/simple.json
+++ b/examples/events/EiffelFlowContextDefinedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelFlowContextDefinedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "product": "MyProduct",

--- a/examples/events/EiffelIssueVerifiedEvent/simple.json
+++ b/examples/events/EiffelIssueVerifiedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelIssueVerifiedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "issues": [
@@ -19,19 +19,19 @@
   "links": [
     {
       "type": "VERIFICATION_BASIS",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "CAUSE",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     },
     {
       "type": "IUT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
     },
     {
       "type": "ENVIRONMENT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
     }
   ]
 }

--- a/examples/events/EiffelSourceChangeCreatedEvent/simple.json
+++ b/examples/events/EiffelSourceChangeCreatedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelSourceChangeCreatedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "gitIdentifier": {
@@ -39,11 +39,11 @@
   "links": [
     {
       "type": "BASE",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "PREVIOUS_VERSION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     }
   ]
 }

--- a/examples/events/EiffelSourceChangeSubmittedEvent/simple.json
+++ b/examples/events/EiffelSourceChangeSubmittedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelSourceChangeSubmittedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "svnIdentifier": {
@@ -22,11 +22,11 @@
   "links": [
     {
       "type": "CHANGE",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "PREVIOUS_VERSION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     }
   ]
 }

--- a/examples/events/EiffelTestCaseCanceledEvent/simple.json
+++ b/examples/events/EiffelTestCaseCanceledEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelTestCaseCanceledEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "reason": "Skipping this test execution due to new IUT version becoming available."
@@ -11,11 +11,11 @@
   "links": [
     {
       "type": "CAUSE",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "TEST_CASE_EXECUTION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     }
   ]
 }

--- a/examples/events/EiffelTestCaseFinishedEvent/simple.json
+++ b/examples/events/EiffelTestCaseFinishedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelTestCaseFinishedEvent",
     "version": "1.0.1",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "outcome": {
@@ -39,7 +39,7 @@
   "links": [
     {
       "type": "TEST_CASE_EXECUTION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/events/EiffelTestCaseStartedEvent/simple.json
+++ b/examples/events/EiffelTestCaseStartedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelTestCaseStartedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "executor": "My Test Framework",
@@ -17,7 +17,7 @@
   "links": [
     {
       "type": "ENVIRONMENT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/events/EiffelTestCaseTriggeredEvent/simple.json
+++ b/examples/events/EiffelTestCaseTriggeredEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelTestCaseTriggeredEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "security": {
       "sdm": {
         "authorIdentity": "My Test Management System",
@@ -36,11 +36,11 @@
   "links": [
     {
       "type": "CONTEXT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     },
     {
       "type": "IUT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
     }
   ]
 }

--- a/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches.json
+++ b/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches.json
@@ -3,7 +3,7 @@
     "type": "EiffelTestExecutionRecipeCollectionCreatedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "selectionStrategy": {
@@ -59,7 +59,7 @@
   "links": [
     {
       "type": "CONTEXT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batchesUri.json
+++ b/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batchesUri.json
@@ -6,7 +6,7 @@
     "source": {
       "domainId": "example.domain"
     },
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "selectionStrategy": {
@@ -19,7 +19,7 @@
   "links": [
     {
       "type": "CONTEXT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/events/EiffelTestSuiteFinishedEvent/simple.json
+++ b/examples/events/EiffelTestSuiteFinishedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelTestSuiteFinishedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "outcome": {
@@ -25,7 +25,7 @@
   "links": [
     {
       "type": "TEST_SUITE_EXECUTION",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/events/EiffelTestSuiteStartedEvent/simple.json
+++ b/examples/events/EiffelTestSuiteStartedEvent/simple.json
@@ -3,7 +3,7 @@
     "type": "EiffelTestSuiteStartedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "name": "Pre-release installation and security verification",
@@ -24,7 +24,7 @@
   "links": [
     {
       "type": "CONTEXT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/flows/build-avoidance/events.json
+++ b/examples/flows/build-avoidance/events.json
@@ -4,7 +4,7 @@
       "type": "EiffelSourceChangeSubmittedEvent",
       "version": "1.0.0",
       "time": 1000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
       "source": {
         "domainId": "example.domain"
       }
@@ -25,7 +25,7 @@
       "type": "EiffelSourceChangeSubmittedEvent",
       "version": "1.0.0",
       "time": 101000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1",
       "source": {
         "domainId": "example.domain"
       }
@@ -41,7 +41,7 @@
     "links": [
       {
         "type": "PREVIOUS_VERSION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
       }
     ]
   },
@@ -50,7 +50,7 @@
       "type": "EiffelCompositionDefinedEvent",
       "version": "1.0.0",
       "time": 2000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2",
       "source": {
         "domainId": "example.domain"
       }
@@ -62,7 +62,7 @@
     "links": [
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
       }
     ]
   },
@@ -71,7 +71,7 @@
       "type": "EiffelCompositionDefinedEvent",
       "version": "1.0.0",
       "time": 102000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3",
       "source": {
         "domainId": "example.domain"
       }
@@ -83,11 +83,11 @@
     "links": [
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
       },
       {
         "type": "PREVIOUS_VERSION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       }
     ]
   },
@@ -96,7 +96,7 @@
       "type": "EiffelArtifactCreatedEvent",
       "version": "1.0.0",
       "time": 3000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4",
       "source": {
         "domainId": "example.domain"
       }
@@ -118,7 +118,7 @@
     "links": [
       {
         "type": "COMPOSITION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       }
     ]
   },
@@ -127,7 +127,7 @@
       "type": "EiffelArtifactCreatedEvent",
       "version": "1.0.0",
       "time": 4000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5",
       "source": {
         "domainId": "example.domain"
       }
@@ -149,7 +149,7 @@
     "links": [
       {
         "type": "COMPOSITION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       }
     ]
   },
@@ -158,7 +158,7 @@
       "type": "EiffelArtifactCreatedEvent",
       "version": "1.0.0",
       "time": 5000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee6",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee6",
       "source": {
         "domainId": "example.domain"
       }
@@ -180,7 +180,7 @@
     "links": [
       {
         "type": "COMPOSITION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       }
     ]
   },
@@ -189,7 +189,7 @@
       "type": "EiffelArtifactCreatedEvent",
       "version": "1.0.0",
       "time": 6000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee7",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee7",
       "source": {
         "domainId": "example.domain"
       }
@@ -211,7 +211,7 @@
     "links": [
       {
         "type": "COMPOSITION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       }
     ]
   },
@@ -220,7 +220,7 @@
       "type": "EiffelArtifactCreatedEvent",
       "version": "1.0.0",
       "time": 7000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee8",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee8",
       "source": {
         "domainId": "example.domain"
       }
@@ -242,7 +242,7 @@
     "links": [
       {
         "type": "COMPOSITION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       }
     ]
   },
@@ -251,7 +251,7 @@
       "type": "EiffelArtifactCreatedEvent",
       "version": "1.0.0",
       "time": 103000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee9",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee9",
       "source": {
         "domainId": "example.domain"
       }
@@ -273,11 +273,11 @@
     "links": [
       {
         "type": "COMPOSITION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
       },
       {
         "type": "PREVIOUS_VERSION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
       }
     ]
   },
@@ -286,7 +286,7 @@
       "type": "EiffelArtifactCreatedEvent",
       "version": "1.0.0",
       "time": 104000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee10",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee10",
       "source": {
         "domainId": "example.domain"
       }
@@ -308,11 +308,11 @@
     "links": [
       {
         "type": "COMPOSITION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
       },
       {
         "type": "PREVIOUS_VERSION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee8"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee8"
       }
     ]
   },
@@ -321,7 +321,7 @@
       "type": "EiffelCompositionDefinedEvent",
       "version": "1.0.0",
       "time": 8000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee11",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee11",
       "source": {
         "domainId": "example.domain"
       }
@@ -333,23 +333,23 @@
     "links": [
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
       },
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5"
       },
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee6"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee6"
       },
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee7"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee7"
       },
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee8"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee8"
       }
     ]
   },
@@ -358,7 +358,7 @@
       "type": "EiffelCompositionDefinedEvent",
       "version": "1.0.0",
       "time": 105000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee12",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee12",
       "source": {
         "domainId": "example.domain"
       }
@@ -370,27 +370,27 @@
     "links": [
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee9"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee9"
       },
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee13"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee13"
       },
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee14"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee14"
       },
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee15"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee15"
       },
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee10"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee10"
       },
       {
         "type": "PREVIOUS_VERSION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee11"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee11"
       }
     ]
   },
@@ -399,7 +399,7 @@
       "type": "EiffelArtifactReusedEvent",
       "version": "1.0.0",
       "time": 102100,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee13",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee13",
       "source": {
         "domainId": "example.domain"
       }
@@ -409,11 +409,11 @@
     "links": [
       {
         "type": "COMPOSITION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
       },
       {
         "type": "REUSED_ARTIFACT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5"
       }
     ]
   },
@@ -422,7 +422,7 @@
       "type": "EiffelArtifactReusedEvent",
       "version": "1.0.0",
       "time": 102200,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee14",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee14",
       "source": {
         "domainId": "example.domain"
       }
@@ -432,11 +432,11 @@
     "links": [
       {
         "type": "COMPOSITION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
       },
       {
         "type": "REUSED_ARTIFACT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee6"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee6"
       }
     ]
   },
@@ -445,7 +445,7 @@
       "type": "EiffelArtifactReusedEvent",
       "version": "1.0.0",
       "time": 102300,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee15",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee15",
       "source": {
         "domainId": "example.domain"
       }
@@ -455,11 +455,11 @@
     "links": [
       {
         "type": "COMPOSITION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
       },
       {
         "type": "REUSED_ARTIFACT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee7"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee7"
       }
     ]
   }

--- a/examples/flows/confidence-level-joining/events.json
+++ b/examples/flows/confidence-level-joining/events.json
@@ -4,7 +4,7 @@
       "type": "EiffelEnvironmentDefinedEvent",
       "version": "1.0.0",
       "time": 1000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
       "source": {
         "domainId": "example.domain"
       }
@@ -22,7 +22,7 @@
       "type": "EiffelCompositionDefinedEvent",
       "version": "1.0.0",
       "time": 2000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1",
       "source": {
         "domainId": "example.domain"
       }
@@ -38,7 +38,7 @@
       "type": "EiffelArtifactCreatedEvent",
       "version": "1.0.0",
       "time": 3000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2",
       "source": {
         "domainId": "example.domain"
       }
@@ -60,15 +60,15 @@
     "links": [
       {
         "type": "CAUSE",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
       },
       {
         "type": "COMPOSITION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
       },
       {
         "type": "ENVIRONMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
       }
     ]
   },
@@ -77,7 +77,7 @@
       "type": "EiffelArtifactPublishedEvent",
       "version": "1.0.0",
       "time": 4000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3",
       "source": {
         "domainId": "example.domain"
       }
@@ -93,11 +93,11 @@
     "links": [
       {
         "type": "CAUSE",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       },
       {
         "type": "ARTIFACT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       }
     ]
   },
@@ -106,7 +106,7 @@
       "type": "EiffelActivityTriggeredEvent",
       "version": "1.0.0",
       "time": 5000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4",
       "source": {
         "domainId": "example.domain"
       }
@@ -124,7 +124,7 @@
     "links": [
       {
         "type": "CAUSE",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
       }
     ]
   },
@@ -133,7 +133,7 @@
       "type": "EiffelActivityTriggeredEvent",
       "version": "1.0.0",
       "time": 6000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5",
       "source": {
         "domainId": "example.domain"
       }
@@ -151,7 +151,7 @@
     "links": [
       {
         "type": "CAUSE",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
       }
     ]
   },
@@ -160,7 +160,7 @@
       "type": "EiffelActivityStartedEvent",
       "version": "1.0.0",
       "time": 7000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee6",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee6",
       "source": {
         "domainId": "example.domain"
       }
@@ -170,7 +170,7 @@
     "links": [
       {
         "type": "ACTIVITY_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
       }
     ]
   },
@@ -179,7 +179,7 @@
       "type": "EiffelActivityStartedEvent",
       "version": "1.0.0",
       "time": 8000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee7",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee7",
       "source": {
         "domainId": "example.domain"
       }
@@ -189,7 +189,7 @@
     "links": [
       {
         "type": "ACTIVITY_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5"
       }
     ]
   },
@@ -198,7 +198,7 @@
       "type": "EiffelTestCaseTriggeredEvent",
       "version": "1.0.0",
       "time": 9000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeea8",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeea8",
       "source": {
         "domainId": "example.domain"
       }
@@ -214,11 +214,11 @@
     "links": [
       {
         "type": "CONTEXT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
       },
       {
         "type": "IUT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       }
     ]
   },
@@ -227,7 +227,7 @@
       "type": "EiffelTestCaseStartedEvent",
       "version": "1.0.0",
       "time": 9001,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee8",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee8",
       "source": {
         "domainId": "example.domain"
       }
@@ -238,7 +238,7 @@
     "links": [
       {
         "type": "TEST_CASE_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeea8"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeea8"
       }
     ]
   },
@@ -247,7 +247,7 @@
       "type": "EiffelTestCaseTriggeredEvent",
       "version": "1.0.0",
       "time": 9000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeea9",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeea9",
       "source": {
         "domainId": "example.domain"
       }
@@ -263,11 +263,11 @@
     "links": [
       {
         "type": "CONTEXT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
       },
       {
         "type": "IUT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       }
     ]
   },
@@ -276,7 +276,7 @@
       "type": "EiffelTestCaseStartedEvent",
       "version": "1.0.0",
       "time": 9001,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee9",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee9",
       "source": {
         "domainId": "example.domain"
       }
@@ -287,7 +287,7 @@
     "links": [
       {
         "type": "TEST_CASE_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeea9"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeea9"
       }
     ]
   },
@@ -296,7 +296,7 @@
       "type": "EiffelTestCaseTriggeredEvent",
       "version": "1.0.0",
       "time": 9000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeea10",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeea10",
       "source": {
         "domainId": "example.domain"
       }
@@ -312,11 +312,11 @@
     "links": [
       {
         "type": "CONTEXT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5"
       },
       {
         "type": "IUT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       }
     ]
   },
@@ -325,7 +325,7 @@
       "type": "EiffelTestCaseStartedEvent",
       "version": "1.0.0",
       "time": 9001,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee10",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee10",
       "source": {
         "domainId": "example.domain"
       }
@@ -336,7 +336,7 @@
     "links": [
       {
         "type": "TEST_CASE_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeea10"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeea10"
       }
     ]
   },
@@ -345,7 +345,7 @@
       "type": "EiffelTestCaseTriggeredEvent",
       "version": "1.0.0",
       "time": 9000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeea11",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeea11",
       "source": {
         "domainId": "example.domain"
       }
@@ -361,11 +361,11 @@
     "links": [
       {
         "type": "CONTEXT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5"
       },
       {
         "type": "IUT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       }
     ]
   },
@@ -374,7 +374,7 @@
       "type": "EiffelTestCaseStartedEvent",
       "version": "1.0.0",
       "time": 9001,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee11",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee11",
       "source": {
         "domainId": "example.domain"
       }
@@ -385,7 +385,7 @@
     "links": [
       {
         "type": "TEST_CASE_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeea11"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeea11"
       }
     ]
   },
@@ -394,7 +394,7 @@
       "type": "EiffelTestCaseFinishedEvent",
       "version": "1.0.0",
       "time": 19000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee12",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee12",
       "source": {
         "domainId": "example.domain"
       }
@@ -419,7 +419,7 @@
     "links": [
       {
         "type": "TEST_CASE_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeea8"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeea8"
       }
     ]
   },
@@ -428,7 +428,7 @@
       "type": "EiffelTestCaseFinishedEvent",
       "version": "1.0.0",
       "time": 14000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee13",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee13",
       "source": {
         "domainId": "example.domain"
       }
@@ -445,7 +445,7 @@
     "links": [
       {
         "type": "TEST_CASE_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeea9"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeea9"
       }
     ]
   },
@@ -454,7 +454,7 @@
       "type": "EiffelTestCaseFinishedEvent",
       "version": "1.0.0",
       "time": 16000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee14",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee14",
       "source": {
         "domainId": "example.domain"
       }
@@ -468,7 +468,7 @@
     "links": [
       {
         "type": "TEST_CASE_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeea10"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeea10"
       }
     ]
   },
@@ -477,7 +477,7 @@
       "type": "EiffelTestCaseFinishedEvent",
       "version": "1.0.0",
       "time": 15000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee15",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee15",
       "source": {
         "domainId": "example.domain"
       }
@@ -491,7 +491,7 @@
     "links": [
       {
         "type": "TEST_CASE_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeea10"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeea10"
       }
     ]
   },
@@ -500,7 +500,7 @@
       "type": "EiffelActivityFinishedEvent",
       "version": "1.0.0",
       "time": 20000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee16",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee16",
       "source": {
         "domainId": "example.domain"
       }
@@ -513,7 +513,7 @@
     "links": [
       {
         "type": "ACTIVITY_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
       }
     ]
   },
@@ -522,7 +522,7 @@
       "type": "EiffelActivityFinishedEvent",
       "version": "1.0.0",
       "time": 20000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee17",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee17",
       "source": {
         "domainId": "example.domain"
       }
@@ -535,7 +535,7 @@
     "links": [
       {
         "type": "ACTIVITY_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5"
       }
     ]
   },
@@ -544,7 +544,7 @@
       "type": "EiffelConfidenceLevelModifiedEvent",
       "version": "1.0.0",
       "time": 21000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee18",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee18",
       "source": {
         "domainId": "example.domain"
       }
@@ -559,23 +559,23 @@
     "links": [
       {
         "type": "CAUSE",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee13"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee13"
       },
       {
         "type": "CAUSE",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee14"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee14"
       },
       {
         "type": "CAUSE",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee15"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee15"
       },
       {
         "type": "CAUSE",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee16"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee16"
       },
       {
         "type": "SUBJECT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       }
     ]
   }

--- a/examples/flows/delivery-interface/events.json
+++ b/examples/flows/delivery-interface/events.json
@@ -4,7 +4,7 @@
       "type": "EiffelSourceChangeSubmittedEvent",
       "version": "1.0.0",
       "time": 1000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
       "source": {
         "domainId": "example.domain"
       }
@@ -27,7 +27,7 @@
       "type": "EiffelSourceChangeCreatedEvent",
       "version": "1.0.0",
       "time": 101000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1",
       "source": {
         "domainId": "example.domain"
       }
@@ -52,7 +52,7 @@
     "links": [
       {
         "type": "BASE",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
       }
     ]
   },
@@ -61,7 +61,7 @@
       "type": "EiffelSourceChangeCreatedEvent",
       "version": "1.0.0",
       "time": 102000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2",
       "source": {
         "domainId": "example.domain"
       }
@@ -85,11 +85,11 @@
     "links": [
       {
         "type": "BASE",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
       },
       {
         "type": "PREVIOUS_VERSION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
       }
     ]
   },
@@ -98,7 +98,7 @@
       "type": "EiffelSourceChangeSubmittedEvent",
       "version": "1.0.0",
       "time": 103000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3",
       "source": {
         "domainId": "example.domain"
       }
@@ -116,11 +116,11 @@
     "links": [
       {
         "type": "CHANGE",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee2"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
       },
       {
         "type": "PREVIOUS_VERSION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
       }
     ]
   },
@@ -129,7 +129,7 @@
       "type": "EiffelSourceChangeCreatedEvent",
       "version": "1.0.0",
       "time": 201000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4",
       "source": {
         "domainId": "example.domain"
       }
@@ -147,7 +147,7 @@
     "links": [
       {
         "type": "BASE",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
       }
     ]
   },
@@ -156,7 +156,7 @@
       "type": "EiffelSourceChangeSubmittedEvent",
       "version": "1.0.0",
       "time": 202000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5",
       "source": {
         "domainId": "example.domain"
       }
@@ -174,11 +174,11 @@
     "links": [
       {
         "type": "CHANGE",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee4"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
       },
       {
         "type": "PREVIOUS_VERSION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
       }
     ]
   },
@@ -187,7 +187,7 @@
       "type": "EiffelCompositionDefinedEvent",
       "version": "1.0.0",
       "time": 2000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee6",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee6",
       "source": {
         "domainId": "example.domain"
       }
@@ -198,7 +198,7 @@
     "links": [
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
       }
     ]
   },
@@ -207,7 +207,7 @@
       "type": "EiffelCompositionDefinedEvent",
       "version": "1.0.0",
       "time": 104000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee7",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee7",
       "source": {
         "domainId": "example.domain"
       }
@@ -219,11 +219,11 @@
     "links": [
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee3"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
       },
       {
         "type": "PREVIOUS_VERSION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee6"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee6"
       }
     ]
   },
@@ -232,7 +232,7 @@
       "type": "EiffelCompositionDefinedEvent",
       "version": "1.0.0",
       "time": 203000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee8",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee8",
       "source": {
         "domainId": "example.domain"
       }
@@ -244,11 +244,11 @@
     "links": [
       {
         "type": "ELEMENT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee5"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5"
       },
       {
         "type": "PREVIOUS_VERSION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee7"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee7"
       }
     ]
   },
@@ -257,7 +257,7 @@
       "type": "EiffelArtifactCreatedEvent",
       "version": "1.0.0",
       "time": 3000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee9",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee9",
       "source": {
         "domainId": "example.domain"
       }
@@ -279,7 +279,7 @@
     "links": [
       {
         "type": "COMPOSITION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee6"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee6"
       }
     ]
   },
@@ -288,7 +288,7 @@
       "type": "EiffelArtifactCreatedEvent",
       "version": "1.0.0",
       "time": 204000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee10",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee10",
       "source": {
         "domainId": "example.domain"
       }
@@ -310,7 +310,7 @@
     "links": [
       {
         "type": "COMPOSITION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee8"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee8"
       }
     ]
   },
@@ -319,7 +319,7 @@
       "type": "EiffelTestCaseTriggeredEvent",
       "version": "1.0.0",
       "time": 4000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeea11",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeea11",
       "source": {
         "domainId": "example.domain"
       }
@@ -335,7 +335,7 @@
     "links": [
       {
         "type": "IUT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee9"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee9"
       }
     ]
   },
@@ -344,7 +344,7 @@
       "type": "EiffelTestCaseStartedEvent",
       "version": "1.0.0",
       "time": 4001,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee11",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee11",
       "source": {
         "domainId": "example.domain"
       }
@@ -355,7 +355,7 @@
     "links": [
       {
         "type": "TEST_CASE_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeea11"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeea11"
       }
     ]
   },
@@ -364,7 +364,7 @@
       "type": "EiffelTestCaseTriggeredEvent",
       "version": "1.0.0",
       "time": 205000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeea12",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeea12",
       "source": {
         "domainId": "example.domain"
       }
@@ -380,7 +380,7 @@
     "links": [
       {
         "type": "IUT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee10"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee10"
       }
     ]
   },
@@ -389,7 +389,7 @@
       "type": "EiffelTestCaseStartedEvent",
       "version": "1.0.0",
       "time": 205001,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee12",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee12",
       "source": {
         "domainId": "example.domain"
       }
@@ -400,7 +400,7 @@
     "links": [
       {
         "type": "TEST_CASE_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeea12"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeea12"
       }
     ]
   },
@@ -409,7 +409,7 @@
       "type": "EiffelTestCaseFinishedEvent",
       "version": "1.0.0",
       "time": 5000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee13",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee13",
       "source": {
         "domainId": "example.domain"
       }
@@ -434,7 +434,7 @@
     "links": [
       {
         "type": "TEST_CASE_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee11"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee11"
       }
     ]
   },
@@ -443,7 +443,7 @@
       "type": "EiffelTestCaseFinishedEvent",
       "version": "1.0.0",
       "time": 206000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee14",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee14",
       "source": {
         "domainId": "example.domain"
       }
@@ -464,7 +464,7 @@
     "links": [
       {
         "type": "TEST_CASE_EXECUTION",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee12"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee12"
       }
     ]
   },
@@ -473,7 +473,7 @@
       "type": "EiffelConfidenceLevelModifiedEvent",
       "version": "1.0.0",
       "time": 6000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee15",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee15",
       "source": {
         "domainId": "example.domain"
       }
@@ -485,7 +485,7 @@
     "links": [
       {
         "type": "SUBJECT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee9"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee9"
       }
     ]
   },
@@ -494,7 +494,7 @@
       "type": "EiffelConfidenceLevelModifiedEvent",
       "version": "1.0.0",
       "time": 207000,
-      "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee16",
+      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee16",
       "source": {
         "domainId": "example.domain"
       }
@@ -506,7 +506,7 @@
     "links": [
       {
         "type": "SUBJECT",
-        "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee10"
+        "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeee10"
       }
     ]
   }

--- a/schemas/EiffelActivityCanceledEvent/1.0.0.json
+++ b/schemas/EiffelActivityCanceledEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -131,7 +132,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelActivityFinishedEvent/1.0.0.json
+++ b/schemas/EiffelActivityFinishedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -172,7 +173,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelActivityStartedEvent/1.0.0.json
+++ b/schemas/EiffelActivityStartedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -150,7 +151,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelActivityTriggeredEvent/1.0.0.json
+++ b/schemas/EiffelActivityTriggeredEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -174,7 +175,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelAnnouncementPublishedEvent/1.0.0.json
+++ b/schemas/EiffelAnnouncementPublishedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -146,7 +147,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelArtifactCreatedEvent/1.0.0.json
+++ b/schemas/EiffelArtifactCreatedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -231,7 +232,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelArtifactPublishedEvent/1.0.0.json
+++ b/schemas/EiffelArtifactPublishedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -156,7 +157,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelArtifactReusedEvent/1.0.0.json
+++ b/schemas/EiffelArtifactReusedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -128,7 +129,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelCompositionDefinedEvent/1.0.0.json
+++ b/schemas/EiffelCompositionDefinedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -137,7 +138,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelConfidenceLevelModifiedEvent/1.0.0.json
+++ b/schemas/EiffelConfidenceLevelModifiedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -157,7 +158,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelEnvironmentDefinedEvent/1.0.0.json
+++ b/schemas/EiffelEnvironmentDefinedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -159,7 +160,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelFlowContextDefinedEvent/1.0.0.json
+++ b/schemas/EiffelFlowContextDefinedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -143,7 +144,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelIssueVerifiedEvent/1.0.0.json
+++ b/schemas/EiffelIssueVerifiedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -175,7 +176,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelSourceChangeCreatedEvent/1.0.0.json
+++ b/schemas/EiffelSourceChangeCreatedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -303,7 +304,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelSourceChangeSubmittedEvent/1.0.0.json
+++ b/schemas/EiffelSourceChangeSubmittedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -236,7 +237,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelTestCaseCanceledEvent/1.0.0.json
+++ b/schemas/EiffelTestCaseCanceledEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -131,7 +132,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelTestCaseFinishedEvent/1.0.0.json
+++ b/schemas/EiffelTestCaseFinishedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -195,7 +196,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelTestCaseFinishedEvent/1.0.1.json
+++ b/schemas/EiffelTestCaseFinishedEvent/1.0.1.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -199,7 +200,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelTestCaseStartedEvent/1.0.0.json
+++ b/schemas/EiffelTestCaseStartedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -150,7 +151,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelTestCaseTriggeredEvent/1.0.0.json
+++ b/schemas/EiffelTestCaseTriggeredEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -209,7 +210,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.json
+++ b/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -228,7 +229,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelTestSuiteFinishedEvent/1.0.0.json
+++ b/schemas/EiffelTestSuiteFinishedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -174,7 +175,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [

--- a/schemas/EiffelTestSuiteStartedEvent/1.0.0.json
+++ b/schemas/EiffelTestSuiteStartedEvent/1.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",
@@ -184,7 +185,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           }
         },
         "required": [


### PR DESCRIPTION
As per issue #152.

All affected examples have been updated.