### PR TITLE
Added DOCKER_REGISTRY as valid ArtifactPublished location type

### DIFF
--- a/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
@@ -27,7 +27,7 @@ __Description:__ A list of locations at which the artifact may be retrieved.
 #### data.locations.type
 __Type:__ String  
 __Required:__ Yes  
-__Legal values:__ ARTIFACTORY, NEXUS, PLAIN, OTHER  
+__Legal values:__ ARTIFACTORY, NEXUS, PLAIN, DOCKER_REGISTRY, OTHER  
 __Description:__ The type of location. May be used by (automated) readers to understand the method of retrieval, particularly with regards to authentication.  
 ARTIFACTORY signifies an [Artifactory](https://www.jfrog.com/artifactory/)  
 NEXUS signifies a [Nexus](http://www.sonatype.org/nexus/)  
@@ -42,6 +42,7 @@ __Description:__ The URI at which the artifact can be retrieved.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
+| 1.1.0     | Current version.                                       | Added DOCKER_REGISTRY as valid value to data.locations.type. |
 | 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples

--- a/examples/events/EiffelArtifactPublishedEvent/simple.json
+++ b/examples/events/EiffelArtifactPublishedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactPublishedEvent",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "security": {

--- a/schemas/EiffelArtifactPublishedEvent/1.1.0.json
+++ b/schemas/EiffelArtifactPublishedEvent/1.1.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",

--- a/schemas/EiffelArtifactPublishedEvent/1.1.0.json
+++ b/schemas/EiffelArtifactPublishedEvent/1.1.0.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["EiffelArtifactPublishedEvent"]
+        },
+        "version": {
+          "type": "string",
+          "enum": [ "1.1.0" ],
+          "default": "1.1.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "object",
+              "properties": {
+                "groupId": {
+                  "type": "string"
+                },
+                "artifactId": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "groupId",
+                "artifactId",
+                "version"
+              ],
+              "additionalProperties": false
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "sdm": {
+              "type": "object",
+              "properties": {
+                "authorIdentity": {
+                  "type": "string"
+                },
+                "encryptedDigest": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authorIdentity",
+                "encryptedDigest"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "locations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ARTIFACTORY",
+                  "NEXUS",
+                  "PLAIN",
+                  "DOCKER_REGISTRY",
+                  "OTHER"
+                ]
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+              }
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "locations"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
As per issue #142.

EiffelArtifactPublishedEvent was stepped to 1.1.0, with DOCKER_REGISTRY
being added to the enum list for data.locations.type.