### PR TITLE
Stepped EiffelTestExecutionRecipeCollectionCreatedEvent to 2.0.0

### DIFF
--- a/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
@@ -98,9 +98,19 @@ __Required:__ No
 __Description:__ A location where a description of the test case can be retrieved.
 
 ##### data.batches.recipes.constraints
-__Type:__ Object  
+__Type:__ Object[]  
 __Required:__ No  
-__Description:__ Any constraints of the execution. The syntax of this object is not controlled, as the nature of such constraints are highly dependent on technology domain and test execution framework. That being said, there are three questions that typically need to be answered: what is the item under test, in what kind of environment is it to be tested, and what are the test parameters?
+__Description:__ Any constraints of the execution. The nature of such constraints is highly dependent on technology domain and test execution framework. Consequently, there are no pre-defined or required constraints. Instead, this property is a list of key-value pairs on the same format as [data.customData](../customization/custom-data.md). That being said, there are three questions that typically need to be answered: what is the item under test, in what kind of environment is it to be tested, and what are the test parameters?
+
+###### data.batches.recipes.constraints.key
+__Type:__ String  
+__Required:__ Yes  
+__Description:__ The key name of constraint.
+
+###### data.batches.recipes.constraints.value
+__Type:__ Any  
+__Required:__ Yes  
+__Description:__ The value of the constraint.
 
 #### data.batches.dependencies
 __Type:__ Object[]  
@@ -120,8 +130,10 @@ __Description:__ The UUID of the dependent execution (__data.batches.recipes.id_
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
+| 2.0.0     | Current version.                                       | Changed syntax of data.batches.recipes.constraints from an uncontrolled object to a list of key-value pairs to comply with design guidelines. |
 | 1.0.0     | [edition-bordeaux](../../../tree/edition-bordeaux)     | Initial version.                        |
 
 ## Examples
 * [Example using data.batches](../examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches.json)
+* [Example using data.batches (1.0.0 syntax)](../examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches-1.0.0.json)
 * [Example using data.batchesUri](../examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batchesUri.json)

--- a/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches-1.0.0.json
+++ b/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches-1.0.0.json
@@ -1,9 +1,9 @@
 {
   "meta": {
     "type": "EiffelTestExecutionRecipeCollectionCreatedEvent",
-    "version": "2.0.0",
+    "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
   },
   "data": {
     "selectionStrategy": {
@@ -23,19 +23,13 @@
               "id": "TC-1234",
               "uri": "http://tm.company.com/browse/TC-1234"
             },
-            "constraints": [
-              {
-                "key": "load",
-                "value": 10000
-              },
-              {
-                "key": "environment",
-                "value": {
-                  "os": "ubuntu-15.04",
-                  "MY_PATH": "/home/lt-worf"
-                }
+            "constraints": {
+              "load": 10000,
+              "environment": {
+                "os": "ubuntu-15.04",
+                "MY_PATH": "/home/lt-worf"
               }
-            ]
+            }
           },
           {
             "id": "aaaaaaaa-bbbb-5ccc-addd-eeeeeeeeeee1",
@@ -44,19 +38,13 @@
               "id": "TC-1234",
               "uri": "http://tm.company.com/browse/TC-1234"
             },
-            "constraints": [
-              {
-                "key": "load",
-                "value": 500
-              },
-              {
-                "key": "environment",
-                "value": {
-                  "os": "ubuntu-16.04.1",
-                  "MY_PATH": "/home/cpt-picard"
-                }
+            "constraints": {
+              "load": 500,
+              "environment": {
+                "os": "ubuntu-16.04.1",
+                "MY_PATH": "/home/cpt-picard"
               }
-            ]
+            }
           }      
         ],
         "dependencies": [
@@ -71,7 +59,7 @@
   "links": [
     {
       "type": "CONTEXT",
-      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches-1.0.0.json
+++ b/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches-1.0.0.json
@@ -3,7 +3,7 @@
     "type": "EiffelTestExecutionRecipeCollectionCreatedEvent",
     "version": "1.0.0",
     "time": 1234567890,
-    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee0"
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {
     "selectionStrategy": {
@@ -59,7 +59,7 @@
   "links": [
     {
       "type": "CONTEXT",
-      "target": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
     }
   ]
 }

--- a/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batchesUri.json
+++ b/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batchesUri.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelTestExecutionRecipeCollectionCreatedEvent",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "time": 1234567890,
     "source": {
       "domainId": "example.domain"

--- a/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/2.0.0.json
+++ b/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/2.0.0.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "type": {
           "type": "string",

--- a/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/2.0.0.json
+++ b/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/2.0.0.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [ "EiffelTestExecutionRecipeCollectionCreatedEvent" ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [ "2.0.0" ],
+          "default": "2.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "object",
+              "properties": {
+                "groupId": {
+                  "type": "string"
+                },
+                "artifactId": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "groupId",
+                "artifactId",
+                "version"
+              ],
+              "additionalProperties": false
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "sdm": {
+              "type": "object",
+              "properties": {
+                "authorIdentity": {
+                  "type": "string"
+                },
+                "encryptedDigest": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authorIdentity",
+                "encryptedDigest"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "selectionStrategy": {
+          "type": "object",
+          "properties": {
+            "tracker": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false
+        },
+        "batchesUri": {
+          "type": "string"
+        },
+        "batches": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "integer"
+              },
+              "recipes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                    },
+                    "testCase": {
+                      "type": "object",
+                      "properties": {
+                        "tracker": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "uri": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "value"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "testCase"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "dependencies": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "dependent": {
+                      "type": "string"
+                    },
+                    "dependency": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "dependent",
+                    "dependency"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "priority",
+              "recipes"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+              }
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "selectionStrategy"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
As per issue #149.

In 2.0.0 of the event, the syntax of data.batches.recipes.constraints changed to comply with protocol design guidelines. It is no longer an uncontrolled object, but a list of key-value pair, identical to data.customData.