### PR TITLE
Added issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--
+Filling out the template is required. Any issue that does not include enough information may be closed at the maintainers' discretion.
+-->
+
+### Description
+<!-- Describe the proposed or requested change, and explain the type of change. Is it a change to the protocol, to the documentation, or something else? -->
+
+### Motivation
+<!-- Why would you like to see this change? -->
+
+### Exemplification
+<!-- Can you think of a concrete example illustrating the impact and value of the change? -->
+
+### Benefits
+<!-- What would the benefits of introducing this change be? -->
+
+### Possible Drawbacks
+<!-- What are the possible side-effects or negative impacts of the change, and why are they outweighed by the benefits? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,3 +17,35 @@ Any pull request must pass the automated Travis tests.
 
 ### Possible Drawbacks
 <!-- What are the possible side-effects or negative impacts of the change? -->
+
+### Sign-off
+<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
+<!-- The certificate is copied from https://developercertificate.org/ -->
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+
+Signed-off-by: <!-- <Your full name> <your-email@example.org> -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+Any pull request must pass the automated Travis tests.
+-->
+
+### Applicable Issues
+<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
+
+### Description of the Change
+<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
+
+### Alternate Designs
+<!-- Explain what other alternates were considered and why the proposed version was selected -->
+
+### Benefits
+<!-- What benefits will be realized by the change? -->
+
+### Possible Drawbacks
+<!-- What are the possible side-effects or negative impacts of the change? -->


### PR DESCRIPTION
Created templates for issues and pull requests, as per issue #159.
The intention is for these templates to be minimalistic and easy
to use, yet guide contributors towards including sufficient
information so as to enable effective discussions and reviews.

The templates are intended to reflect the contribution guidelines,
while aligning to generally accepted good practice.